### PR TITLE
release: v0.2.0

### DIFF
--- a/bin/prepare/install-org-plugin.sh
+++ b/bin/prepare/install-org-plugin.sh
@@ -38,10 +38,10 @@ if [[ ! -f ${README} ]]; then
 fi
 
 if [[ -n "${WP_VERSION}" && ${WP_VERSION} =~ ^[0-9]+\.[0-9]+$ && -z "${IGNORE_PLUGIN_VERSION}" ]]; then
-  UPPER_CASE_SLUG=$(echo ${PLUGIN_SLUG} | tr "[a-z]" "[A-Z]")
+  UPPER_CASE_SLUG=$(echo ${PLUGIN_SLUG} | tr "[:lower:]" "[:upper:]")
   IGNORE_EACH_PLUGIN_VERSION=$(eval echo '$'IGNORE_${UPPER_CASE_SLUG//-/_}_VERSION)
   if [[ -z "${IGNORE_EACH_PLUGIN_VERSION}" ]]; then
-    REQUIRED_VERSION=$(cat ${README} | grep "Requires at least" | sed -e 's/Requires at least: *//')
+    REQUIRED_VERSION=$(< ${README} grep "Requires at least" | sed -e 's/Requires at least: *//')
     if [[ -n "${REQUIRED_VERSION}" ]]; then
       echo "Required version: ${REQUIRED_VERSION}"
       echo "WP version: ${WP_VERSION}"
@@ -56,10 +56,10 @@ fi
 
 PHP_VERSION=$(php -r 'echo PHP_VERSION;')
 if [[ -n "${PHP_VERSION}" && -z "${IGNORE_PHP_VERSION}" ]]; then
-  UPPER_CASE_SLUG=$(echo ${PLUGIN_SLUG} | tr "[a-z]" "[A-Z]")
+  UPPER_CASE_SLUG=$(echo ${PLUGIN_SLUG} | tr "[:lower:]" "[:upper:]")
   IGNORE_EACH_PHP_VERSION=$(eval echo '$'IGNORE_${UPPER_CASE_SLUG//-/_}_PHP_VERSION)
   if [[ -z "${IGNORE_EACH_PHP_VERSION}" ]]; then
-    REQUIRED_VERSION=$(cat ${README} | grep "Requires PHP" | sed -e 's/Requires PHP: *//')
+    REQUIRED_VERSION=$(< ${README} grep "Requires PHP" | sed -e 's/Requires PHP: *//')
     if [[ -n "${REQUIRED_VERSION}" ]]; then
       echo "Required PHP version: ${REQUIRED_VERSION}"
       echo "PHP version: ${PHP_VERSION}"

--- a/bin/prepare/install-org-plugin.sh
+++ b/bin/prepare/install-org-plugin.sh
@@ -38,10 +38,10 @@ if [[ ! -f ${README} ]]; then
 fi
 
 if [[ -n "${WP_VERSION}" && ${WP_VERSION} =~ ^[0-9]+\.[0-9]+$ && -z "${IGNORE_PLUGIN_VERSION}" ]]; then
-  UPPER_CASE_SLUG=${PLUGIN_SLUG^^}
+  UPPER_CASE_SLUG=$(echo ${PLUGIN_SLUG} | tr "[a-z]" "[A-Z]")
   IGNORE_EACH_PLUGIN_VERSION=$(eval echo '$'IGNORE_${UPPER_CASE_SLUG//-/_}_VERSION)
   if [[ -z "${IGNORE_EACH_PLUGIN_VERSION}" ]]; then
-    REQUIRED_VERSION=$(cat ${README} | grep "Requires at least" | sed -e 's/Requires at least:\s*//')
+    REQUIRED_VERSION=$(cat ${README} | grep "Requires at least" | sed -e 's/Requires at least: *//')
     if [[ -n "${REQUIRED_VERSION}" ]]; then
       echo "Required version: ${REQUIRED_VERSION}"
       echo "WP version: ${WP_VERSION}"

--- a/bin/prepare/install-org-plugin.sh
+++ b/bin/prepare/install-org-plugin.sh
@@ -54,6 +54,24 @@ if [[ -n "${WP_VERSION}" && ${WP_VERSION} =~ ^[0-9]+\.[0-9]+$ && -z "${IGNORE_PL
   fi
 fi
 
+PHP_VERSION=$(php -r 'echo PHP_VERSION;')
+if [[ -n "${PHP_VERSION}" && -z "${IGNORE_PHP_VERSION}" ]]; then
+  UPPER_CASE_SLUG=$(echo ${PLUGIN_SLUG} | tr "[a-z]" "[A-Z]")
+  IGNORE_EACH_PHP_VERSION=$(eval echo '$'IGNORE_${UPPER_CASE_SLUG//-/_}_PHP_VERSION)
+  if [[ -z "${IGNORE_EACH_PHP_VERSION}" ]]; then
+    REQUIRED_VERSION=$(cat ${README} | grep "Requires PHP" | sed -e 's/Requires PHP: *//')
+    if [[ -n "${REQUIRED_VERSION}" ]]; then
+      echo "Required PHP version: ${REQUIRED_VERSION}"
+      echo "PHP version: ${PHP_VERSION}"
+      if [[ "${REQUIRED_VERSION}" != $(echo -e "${REQUIRED_VERSION}\n${PHP_VERSION}" | sort -V | head -n1) ]]; then
+        echo "Not enough version..."
+        rm -rdf ${TRAVIS_BUILD_DIR}/.plugin/${PLUGIN_SLUG}
+        UNZIP=0
+      fi
+    fi
+  fi
+fi
+
 if [[ ${UNZIP} == 1 ]]; then
   rm -rdf ${TRAVIS_BUILD_DIR}/.plugin/${PLUGIN_SLUG}
 

--- a/gh-pages/gutenberg/yarn.lock
+++ b/gh-pages/gutenberg/yarn.lock
@@ -896,9 +896,9 @@
     "@emotion/weak-memoize" "0.2.5"
 
 "@emotion/core@^10.0.22":
-  version "10.0.34"
-  resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.0.34.tgz#a643889dc32bdde829482539c9438a026631187c"
-  integrity sha512-Kcs8WHZG1NgaVFQsSpgN07G0xpfPAKUclwKvUqKrYrJovezl9uTz++1M4JfXHrgFVEiJ5QO46hMo1ZDDfvY/tw==
+  version "10.0.35"
+  resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.0.35.tgz#513fcf2e22cd4dfe9d3894ed138c9d7a859af9b3"
+  integrity sha512-sH++vJCdk025fBlRZSAhkRlSUoqSqgCzYf5fMOmqqi3bM6how+sQpg3hkgJonj8GxXM4WbD7dRO+4tegDB9fUw==
   dependencies:
     "@babel/runtime" "^7.5.5"
     "@emotion/cache" "^10.0.27"
@@ -2535,9 +2535,9 @@ camelize@^1.0.0:
   integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
 caniuse-lite@^1.0.30001111:
-  version "1.0.30001115"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001115.tgz#c04cd828883ba47f6f776312e0817bcc9040cfa4"
-  integrity sha512-NZrG0439ePYna44lJX8evHX2L7Z3/z3qjVLnHgbBb/duNEnGo348u+BQS5o4HTWcrb++100dHFrU36IesIrC1Q==
+  version "1.0.30001116"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001116.tgz#f3a3dea347f9294a3bdc4292309039cc84117fb8"
+  integrity sha512-f2lcYnmAI5Mst9+g0nkMIznFGsArRmZ0qU+dnq8l91hymdc2J3SFbiPhOJEeDqC1vtE8nc1qNQyklzB8veJefQ==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -3096,9 +3096,9 @@ ecc-jsbn@~0.1.1:
     safer-buffer "^2.1.0"
 
 electron-to-chromium@^1.3.523:
-  version "1.3.534"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.534.tgz#fc7af8518dd00a5b22a24aed3f116b5d097e2330"
-  integrity sha512-7x2S3yUrspNHQOoPk+Eo+iHViSiJiEGPI6BpmLy1eT2KRNGCkBt/NUYqjfXLd1DpDCQp7n3+LfA1RkbG+LqTZQ==
+  version "1.3.536"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.536.tgz#78a4ff753111283489f3b6ad19664902245ab876"
+  integrity sha512-aU16nvH8/zNNeFIQ7H2SKRQlJ/srw7mCn/JDj2ImWUA7Lk2+3zJFpDGJNP2qRxPAZsC+qgnlgNTYIvT6EOdJFQ==
 
 elliptic@^6.5.3:
   version "6.5.3"
@@ -6461,9 +6461,9 @@ terser@^4.1.2:
     source-map-support "~0.5.12"
 
 terser@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.1.0.tgz#1f4ab81c8619654fdded51f3157b001e1747281d"
-  integrity sha512-pwC1Jbzahz1ZPU87NQ8B3g5pKbhyJSiHih4gLH6WZiPU8mmS1IlGbB0A2Nuvkj/LCNsgIKctg6GkYwWCeTvXZQ==
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.2.0.tgz#e547d0b20926b321d3e524bf9e5bc1b10ba2f360"
+  integrity sha512-nZ9TWhBznZdlww3borgJyfQDrxzpgd0RlRNoxR63tMVry01lIH/zKQDTTiaWRMGowydfvSHMgyiGyn6A9PSkCQ==
   dependencies:
     commander "^2.20.0"
     source-map "~0.6.1"

--- a/gh-pages/page/yarn.lock
+++ b/gh-pages/page/yarn.lock
@@ -1552,9 +1552,9 @@ camelcase@^6.0.0:
   integrity sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==
 
 caniuse-lite@^1.0.30001111:
-  version "1.0.30001115"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001115.tgz#c04cd828883ba47f6f776312e0817bcc9040cfa4"
-  integrity sha512-NZrG0439ePYna44lJX8evHX2L7Z3/z3qjVLnHgbBb/duNEnGo348u+BQS5o4HTWcrb++100dHFrU36IesIrC1Q==
+  version "1.0.30001116"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001116.tgz#f3a3dea347f9294a3bdc4292309039cc84117fb8"
+  integrity sha512-f2lcYnmAI5Mst9+g0nkMIznFGsArRmZ0qU+dnq8l91hymdc2J3SFbiPhOJEeDqC1vtE8nc1qNQyklzB8veJefQ==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -1997,9 +1997,9 @@ ecc-jsbn@~0.1.1:
     safer-buffer "^2.1.0"
 
 electron-to-chromium@^1.3.523:
-  version "1.3.534"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.534.tgz#fc7af8518dd00a5b22a24aed3f116b5d097e2330"
-  integrity sha512-7x2S3yUrspNHQOoPk+Eo+iHViSiJiEGPI6BpmLy1eT2KRNGCkBt/NUYqjfXLd1DpDCQp7n3+LfA1RkbG+LqTZQ==
+  version "1.3.536"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.536.tgz#78a4ff753111283489f3b6ad19664902245ab876"
+  integrity sha512-aU16nvH8/zNNeFIQ7H2SKRQlJ/srw7mCn/JDj2ImWUA7Lk2+3zJFpDGJNP2qRxPAZsC+qgnlgNTYIvT6EOdJFQ==
 
 elliptic@^6.5.3:
   version "6.5.3"
@@ -4683,9 +4683,9 @@ terser@^4.1.2:
     source-map-support "~0.5.12"
 
 terser@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.1.0.tgz#1f4ab81c8619654fdded51f3157b001e1747281d"
-  integrity sha512-pwC1Jbzahz1ZPU87NQ8B3g5pKbhyJSiHih4gLH6WZiPU8mmS1IlGbB0A2Nuvkj/LCNsgIKctg6GkYwWCeTvXZQ==
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.2.0.tgz#e547d0b20926b321d3e524bf9e5bc1b10ba2f360"
+  integrity sha512-nZ9TWhBznZdlww3borgJyfQDrxzpgd0RlRNoxR63tMVry01lIH/zKQDTTiaWRMGowydfvSHMgyiGyn6A9PSkCQ==
   dependencies:
     commander "^2.20.0"
     source-map "~0.6.1"


### PR DESCRIPTION
<!-- START pr-commits   please keep comment here to allow auto update -->
## Changes


* feat: add php version check (b2c1df3b3533ab73d7595ae3110b639c89a0aea9)
* chore: update dependencies (5004eb60540c90b672fe042be0c3ba47fff60c63)
* chore: consider mac (e95dc86a8c1563168fbc5650c65f915f963b06a9)
* chore: tweaks (e7300fc3f914501498b6610838038da69867fb47)

<!-- END pr-commits   please keep comment here to allow auto update -->

## Base PullRequest

default branch (https://github.com/wp-content-framework/travis-ci/tree/master)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/bin
```



</details>
<details>
<summary><em>composer bin:update</em></summary>

```Shell
yarn add v1.22.4
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@2.1.3: The platform "linux" is incompatible with this module.
info "fsevents@2.1.3" is an optional dependency and failed compatibility check. Excluding it from installation.
info fsevents@1.2.13: The platform "linux" is incompatible with this module.
info "fsevents@1.2.13" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved 50 new dependencies.
info Direct dependencies
├─ @wordpress/a11y@2.11.0
├─ @wordpress/annotations@1.20.4
├─ @wordpress/api-fetch@3.18.0
├─ @wordpress/autop@2.9.0
├─ @wordpress/babel-plugin-import-jsx-pragma@2.7.0
├─ @wordpress/blob@2.9.0
├─ @wordpress/block-directory@1.13.6
├─ @wordpress/block-editor@4.3.6
├─ @wordpress/block-library@2.22.6
├─ @wordpress/block-serialization-default-parser@3.7.0
├─ @wordpress/block-serialization-spec-parser@3.7.0
├─ @wordpress/blocks@6.20.3
├─ @wordpress/components@10.0.5
├─ @wordpress/compose@3.19.3
├─ @wordpress/core-data@2.20.3
├─ @wordpress/data-controls@1.16.3
├─ @wordpress/data@4.22.3
├─ @wordpress/date@3.10.0
├─ @wordpress/deprecated@2.9.0
├─ @wordpress/dom-ready@2.10.0
├─ @wordpress/dom@2.13.1
├─ @wordpress/edit-post@3.21.6
├─ @wordpress/edit-site@1.11.6
├─ @wordpress/editor@9.20.6
├─ @wordpress/element@2.16.0
├─ @wordpress/escape-html@1.9.0
├─ @wordpress/format-library@1.22.6
├─ @wordpress/hooks@2.9.0
├─ @wordpress/html-entities@2.8.0
├─ @wordpress/i18n@3.14.0
├─ @wordpress/icons@2.4.0
├─ @wordpress/is-shallow-equal@2.1.0
├─ @wordpress/keyboard-shortcuts@1.9.3
├─ @wordpress/keycodes@2.14.0
├─ @wordpress/list-reusable-blocks@1.21.5
├─ @wordpress/media-utils@1.15.0
├─ @wordpress/notices@2.8.3
├─ @wordpress/nux@3.20.5
├─ @wordpress/plugins@2.20.3
├─ @wordpress/primitives@1.7.0
├─ @wordpress/priority-queue@1.7.0
├─ @wordpress/redux-routine@3.10.0
├─ @wordpress/rich-text@3.20.4
├─ @wordpress/server-side-render@1.16.5
├─ @wordpress/shortcode@2.9.0
├─ @wordpress/token-list@1.11.0
├─ @wordpress/url@2.17.0
├─ @wordpress/viewport@2.21.3
├─ @wordpress/warning@1.2.0
└─ @wordpress/wordcount@2.10.0
info All dependencies
├─ @wordpress/a11y@2.11.0
├─ @wordpress/annotations@1.20.4
├─ @wordpress/api-fetch@3.18.0
├─ @wordpress/autop@2.9.0
├─ @wordpress/babel-plugin-import-jsx-pragma@2.7.0
├─ @wordpress/blob@2.9.0
├─ @wordpress/block-directory@1.13.6
├─ @wordpress/block-editor@4.3.6
├─ @wordpress/block-library@2.22.6
├─ @wordpress/block-serialization-default-parser@3.7.0
├─ @wordpress/block-serialization-spec-parser@3.7.0
├─ @wordpress/blocks@6.20.3
├─ @wordpress/components@10.0.5
├─ @wordpress/compose@3.19.3
├─ @wordpress/core-data@2.20.3
├─ @wordpress/data-controls@1.16.3
├─ @wordpress/data@4.22.3
├─ @wordpress/date@3.10.0
├─ @wordpress/deprecated@2.9.0
├─ @wordpress/dom-ready@2.10.0
├─ @wordpress/dom@2.13.1
├─ @wordpress/edit-post@3.21.6
├─ @wordpress/edit-site@1.11.6
├─ @wordpress/editor@9.20.6
├─ @wordpress/element@2.16.0
├─ @wordpress/escape-html@1.9.0
├─ @wordpress/format-library@1.22.6
├─ @wordpress/hooks@2.9.0
├─ @wordpress/html-entities@2.8.0
├─ @wordpress/i18n@3.14.0
├─ @wordpress/icons@2.4.0
├─ @wordpress/is-shallow-equal@2.1.0
├─ @wordpress/keyboard-shortcuts@1.9.3
├─ @wordpress/keycodes@2.14.0
├─ @wordpress/list-reusable-blocks@1.21.5
├─ @wordpress/media-utils@1.15.0
├─ @wordpress/notices@2.8.3
├─ @wordpress/nux@3.20.5
├─ @wordpress/plugins@2.20.3
├─ @wordpress/primitives@1.7.0
├─ @wordpress/priority-queue@1.7.0
├─ @wordpress/redux-routine@3.10.0
├─ @wordpress/rich-text@3.20.4
├─ @wordpress/server-side-render@1.16.5
├─ @wordpress/shortcode@2.9.0
├─ @wordpress/token-list@1.11.0
├─ @wordpress/url@2.17.0
├─ @wordpress/viewport@2.21.3
├─ @wordpress/warning@1.2.0
└─ @wordpress/wordcount@2.10.0
Done in 58.79s.

All dependencies match the latest package versions :)
yarn install v1.22.4
info No lockfile found.
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@2.1.3: The platform "linux" is incompatible with this module.
info "fsevents@2.1.3" is an optional dependency and failed compatibility check. Excluding it from installation.
info fsevents@1.2.13: The platform "linux" is incompatible with this module.
info "fsevents@1.2.13" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
Done in 11.10s.
yarn upgrade v1.22.4
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@2.1.3: The platform "linux" is incompatible with this module.
info "fsevents@2.1.3" is an optional dependency and failed compatibility check. Excluding it from installation.
info fsevents@1.2.13: The platform "linux" is incompatible with this module.
info "fsevents@1.2.13" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Rebuilding all packages...
success Saved lockfile.
success Saved 560 new dependencies.
info Direct dependencies
├─ @babel/core@7.11.1
├─ @babel/plugin-transform-react-jsx@7.10.4
├─ @babel/plugin-transform-runtime@7.11.0
├─ @babel/preset-env@7.11.0
├─ @babel/register@7.10.5
├─ @wordpress/annotations@1.20.4
├─ @wordpress/babel-plugin-import-jsx-pragma@2.7.0
├─ @wordpress/block-directory@1.13.6
├─ @wordpress/block-serialization-spec-parser@3.7.0
├─ @wordpress/edit-site@1.11.6
├─ @wordpress/format-library@1.22.6
├─ @wordpress/list-reusable-blocks@1.21.5
├─ @wordpress/nux@3.20.5
├─ babel-loader@8.1.0
├─ css-loader@4.2.1
├─ lodash@4.17.20
├─ node-sass@4.14.1
├─ sass-loader@9.0.3
├─ speed-measure-webpack-plugin@1.3.3
├─ style-loader@1.2.1
├─ terser-webpack-plugin@4.1.0
├─ webpack-cli@3.3.12
└─ webpack@4.44.1
info All dependencies
├─ @babel/code-frame@7.10.4
├─ @babel/compat-data@7.11.0
├─ @babel/core@7.11.1
├─ @babel/helper-builder-binary-assignment-operator-visitor@7.10.4
├─ @babel/helper-builder-react-jsx-experimental@7.10.5
├─ @babel/helper-builder-react-jsx@7.10.4
├─ @babel/helper-compilation-targets@7.10.4
├─ @babel/helper-define-map@7.10.5
├─ @babel/helper-explode-assignable-expression@7.10.4
├─ @babel/helper-hoist-variables@7.10.4
├─ @babel/helper-member-expression-to-functions@7.11.0
├─ @babel/helper-module-imports@7.10.4
├─ @babel/helper-wrap-function@7.10.4
├─ @babel/helpers@7.10.4
├─ @babel/highlight@7.10.4
├─ @babel/parser@7.11.3
├─ @babel/plugin-proposal-async-generator-functions@7.10.5
├─ @babel/plugin-proposal-class-properties@7.10.4
├─ @babel/plugin-proposal-dynamic-import@7.10.4
├─ @babel/plugin-proposal-export-namespace-from@7.10.4
├─ @babel/plugin-proposal-json-strings@7.10.4
├─ @babel/plugin-proposal-logical-assignment-operators@7.11.0
├─ @babel/plugin-proposal-nullish-coalescing-operator@7.10.4
├─ @babel/plugin-proposal-numeric-separator@7.10.4
├─ @babel/plugin-proposal-optional-catch-binding@7.10.4
├─ @babel/plugin-proposal-optional-chaining@7.11.0
├─ @babel/plugin-proposal-private-methods@7.10.4
├─ @babel/plugin-proposal-unicode-property-regex@7.10.4
├─ @babel/plugin-syntax-class-properties@7.10.4
├─ @babel/plugin-syntax-jsx@7.10.4
├─ @babel/plugin-syntax-top-level-await@7.10.4
├─ @babel/plugin-transform-arrow-functions@7.10.4
├─ @babel/plugin-transform-async-to-generator@7.10.4
├─ @babel/plugin-transform-block-scoped-functions@7.10.4
├─ @babel/plugin-transform-block-scoping@7.11.1
├─ @babel/plugin-transform-classes@7.10.4
├─ @babel/plugin-transform-computed-properties@7.10.4
├─ @babel/plugin-transform-destructuring@7.10.4
├─ @babel/plugin-transform-dotall-regex@7.10.4
├─ @babel/plugin-transform-duplicate-keys@7.10.4
├─ @babel/plugin-transform-exponentiation-operator@7.10.4
├─ @babel/plugin-transform-for-of@7.10.4
├─ @babel/plugin-transform-function-name@7.10.4
├─ @babel/plugin-transform-literals@7.10.4
├─ @babel/plugin-transform-member-expression-literals@7.10.4
├─ @babel/plugin-transform-modules-amd@7.10.5
├─ @babel/plugin-transform-modules-commonjs@7.10.4
├─ @babel/plugin-transform-modules-systemjs@7.10.5
├─ @babel/plugin-transform-modules-umd@7.10.4
├─ @babel/plugin-transform-named-capturing-groups-regex@7.10.4
├─ @babel/plugin-transform-new-target@7.10.4
├─ @babel/plugin-transform-object-super@7.10.4
├─ @babel/plugin-transform-property-literals@7.10.4
├─ @babel/plugin-transform-react-jsx@7.10.4
├─ @babel/plugin-transform-regenerator@7.10.4
├─ @babel/plugin-transform-reserved-words@7.10.4
├─ @babel/plugin-transform-runtime@7.11.0
├─ @babel/plugin-transform-shorthand-properties@7.10.4
├─ @babel/plugin-transform-spread@7.11.0
├─ @babel/plugin-transform-sticky-regex@7.10.4
├─ @babel/plugin-transform-template-literals@7.10.5
├─ @babel/plugin-transform-typeof-symbol@7.10.4
├─ @babel/plugin-transform-unicode-escapes@7.10.4
├─ @babel/plugin-transform-unicode-regex@7.10.4
├─ @babel/preset-env@7.11.0
├─ @babel/preset-modules@0.1.3
├─ @babel/register@7.10.5
├─ @emotion/cache@10.0.29
├─ @emotion/core@10.0.35
├─ @emotion/css@10.0.27
├─ @emotion/is-prop-valid@0.8.8
├─ @emotion/native@10.0.27
├─ @emotion/primitives-core@10.0.27
├─ @emotion/styled-base@10.0.31
├─ @emotion/styled@10.0.27
├─ @emotion/stylis@0.8.5
├─ @emotion/unitless@0.7.5
├─ @emotion/weak-memoize@0.2.5
├─ @npmcli/move-file@1.0.1
├─ @popperjs/core@2.4.4
├─ @tannin/compile@1.1.0
├─ @tannin/evaluate@1.2.0
├─ @tannin/plural-forms@1.1.0
├─ @tannin/postfix@1.1.0
├─ @types/json-schema@7.0.5
├─ @types/node@14.6.0
├─ @types/parse-json@4.0.0
├─ @webassemblyjs/floating-point-hex-parser@1.9.0
├─ @webassemblyjs/helper-code-frame@1.9.0
├─ @webassemblyjs/helper-fsm@1.9.0
├─ @webassemblyjs/helper-wasm-section@1.9.0
├─ @webassemblyjs/wasm-edit@1.9.0
├─ @webassemblyjs/wasm-opt@1.9.0
├─ @wordpress/annotations@1.20.4
├─ @wordpress/babel-plugin-import-jsx-pragma@2.7.0
├─ @wordpress/block-directory@1.13.6
├─ @wordpress/block-serialization-spec-parser@3.7.0
├─ @wordpress/edit-site@1.11.6
├─ @wordpress/format-library@1.22.6
├─ @wordpress/list-reusable-blocks@1.21.5
├─ @wordpress/nux@3.20.5
├─ @xtuc/ieee754@1.2.0
├─ abbrev@1.1.1
├─ acorn@6.4.1
├─ aggregate-error@3.0.1
├─ ajv-errors@1.0.1
├─ ajv-keywords@3.5.2
├─ ajv@6.12.4
├─ amdefine@1.0.1
├─ ansi-styles@3.2.1
├─ anymatch@3.1.1
├─ are-we-there-yet@1.1.5
├─ arr-flatten@1.1.0
├─ array-find-index@1.0.2
├─ array.prototype.find@2.1.1
├─ array.prototype.flat@1.2.3
├─ asap@2.0.6
├─ asn1.js@5.4.1
├─ asn1@0.2.4
├─ assert@1.5.0
├─ assign-symbols@1.0.0
├─ async-each@1.0.3
├─ async-foreach@0.1.3
├─ asynckit@0.4.0
├─ atob@2.1.2
├─ autosize@4.0.2
├─ aws-sign2@0.7.0
├─ aws4@1.10.1
├─ babel-loader@8.1.0
├─ babel-plugin-macros@2.8.0
├─ babel-plugin-syntax-jsx@6.18.0
├─ balanced-match@1.0.0
├─ base@0.11.2
├─ bcrypt-pbkdf@1.0.2
├─ binary-extensions@2.1.0
├─ block-stream@0.0.9
├─ bluebird@3.7.2
├─ brace-expansion@1.1.11
├─ braces@2.3.2
├─ brcast@2.0.2
├─ browserify-aes@1.2.0
├─ browserify-cipher@1.0.1
├─ browserify-des@1.0.2
├─ browserify-rsa@4.0.1
├─ browserify-sign@4.2.1
├─ browserify-zlib@0.2.0
├─ browserslist@4.14.0
├─ buffer-xor@1.0.3
├─ buffer@4.9.2
├─ builtin-status-codes@3.0.0
├─ cacache@15.0.5
├─ cache-base@1.0.1
├─ callsites@3.1.0
├─ camelcase-keys@2.1.0
├─ camelize@1.0.0
├─ caniuse-lite@1.0.30001116
├─ caseless@0.12.0
├─ chokidar@3.4.2
├─ chrome-trace-event@1.0.2
├─ cipher-base@1.0.4
├─ class-utils@0.3.6
├─ clean-stack@2.2.0
├─ clipboard@2.0.6
├─ code-point-at@1.1.0
├─ collection-visit@1.0.0
├─ color-convert@1.9.3
├─ color-name@1.1.3
├─ combined-stream@1.0.8
├─ compute-scroll-into-view@1.0.14
├─ computed-style@0.1.4
├─ concat-map@0.0.1
├─ concat-stream@1.6.2
├─ console-browserify@1.2.0
├─ console-control-strings@1.1.0
├─ constants-browserify@1.0.0
├─ convert-source-map@1.7.0
├─ copy-concurrently@1.0.5
├─ copy-descriptor@0.1.1
├─ core-js-compat@3.6.5
├─ core-js@1.2.7
├─ core-util-is@1.0.2
├─ cosmiconfig@6.0.0
├─ create-ecdh@4.0.4
├─ create-hmac@1.1.7
├─ cross-spawn@3.0.1
├─ crypto-browserify@3.12.0
├─ css-color-keywords@1.0.0
├─ css-loader@4.2.1
├─ css-mediaquery@0.1.2
├─ css-to-react-native@2.3.2
├─ csstype@2.6.13
├─ currently-unhandled@0.4.1
├─ cyclist@1.0.1
├─ dashdash@1.14.1
├─ debug@2.6.9
├─ decode-uri-component@0.2.0
├─ deepmerge@1.5.2
├─ delayed-stream@1.0.0
├─ delegate@3.2.0
├─ des.js@1.0.1
├─ detect-file@1.0.0
├─ diff@4.0.2
├─ diffie-hellman@5.0.3
├─ direction@1.0.4
├─ document.contains@1.0.2
├─ domain-browser@1.2.0
├─ downloadjs@1.4.7
├─ downshift@5.4.7
├─ duplexify@3.7.1
├─ ecc-jsbn@0.1.2
├─ electron-to-chromium@1.3.536
├─ emoji-regex@7.0.3
├─ encoding@0.1.13
├─ enhanced-resolve@4.3.0
├─ errno@0.1.7
├─ error-ex@1.3.2
├─ es-to-primitive@1.2.1
├─ escalade@3.0.2
├─ escape-string-regexp@1.0.5
├─ eslint-scope@4.0.3
├─ esrecurse@4.2.1
├─ estraverse@4.3.0
├─ esutils@2.0.3
├─ events@3.2.0
├─ evp_bytestokey@1.0.3
├─ expand-brackets@2.1.4
├─ expand-tilde@2.0.2
├─ extend@3.0.2
├─ extglob@2.0.4
├─ extsprintf@1.3.0
├─ fast-average-color@4.3.0
├─ fast-deep-equal@3.1.3
├─ fast-json-stable-stringify@2.1.0
├─ fast-memoize@2.5.2
├─ fbjs@0.8.17
├─ file-saver@2.0.2
├─ fill-range@4.0.0
├─ find-root@1.1.0
├─ findup-sync@3.0.0
├─ flush-write-stream@1.1.1
├─ for-in@1.0.2
├─ forever-agent@0.6.1
├─ form-data@2.3.3
├─ from2@2.3.0
├─ fs.realpath@1.0.0
├─ fstream@1.0.12
├─ function.prototype.name@1.1.2
├─ functions-have-names@1.2.1
├─ gauge@2.7.4
├─ gaze@1.1.3
├─ gensync@1.0.0-beta.1
├─ getpass@0.1.7
├─ gettext-parser@1.4.0
├─ glob-parent@5.1.1
├─ global-cache@1.2.1
├─ global-modules@2.0.0
├─ global-prefix@3.0.0
├─ globule@1.3.2
├─ good-listener@1.2.2
├─ graceful-fs@4.2.4
├─ gradient-parser@0.1.5
├─ har-schema@2.0.0
├─ har-validator@5.1.5
├─ has-ansi@2.0.0
├─ has-unicode@2.0.1
├─ has-value@1.0.0
├─ hash.js@1.1.7
├─ hmac-drbg@1.0.1
├─ hoist-non-react-statics@3.3.2
├─ hosted-git-info@2.8.8
├─ hpq@1.3.0
├─ http-signature@1.2.0
├─ https-browserify@1.0.0
├─ iconv-lite@0.6.2
├─ icss-utils@4.1.1
├─ immediate@3.0.6
├─ import-fresh@3.2.1
├─ import-local@2.0.0
├─ in-publish@2.0.1
├─ indent-string@2.1.0
├─ indexes-of@1.0.1
├─ infer-owner@1.0.4
├─ inflight@1.0.6
├─ ini@1.3.5
├─ interpret@1.4.0
├─ is-accessor-descriptor@1.0.0
├─ is-arrayish@0.2.1
├─ is-binary-path@2.1.0
├─ is-callable@1.2.0
├─ is-data-descriptor@1.0.0
├─ is-date-object@1.0.2
├─ is-descriptor@1.0.2
├─ is-extglob@2.1.1
├─ is-finite@1.1.0
├─ is-glob@4.0.1
├─ is-plain-object@2.0.4
├─ is-stream@1.1.0
├─ is-symbol@1.0.3
├─ is-touch-device@1.0.1
├─ is-typedarray@1.0.0
├─ is-utf8@0.2.1
├─ is-wsl@1.1.0
├─ isarray@1.0.0
├─ isexe@2.0.0
├─ isomorphic-fetch@2.2.1
├─ isstream@0.1.2
├─ jest-worker@26.3.0
├─ js-base64@2.6.4
├─ js-tokens@4.0.0
├─ jsesc@2.5.2
├─ json-parse-better-errors@1.0.2
├─ json-schema-traverse@0.4.1
├─ json-schema@0.2.3
├─ json-stringify-safe@5.0.1
├─ jsprim@1.4.1
├─ jszip@3.5.0
├─ kind-of@3.2.2
├─ klona@1.1.2
├─ leven@3.1.0
├─ lie@3.3.0
├─ line-height@0.3.1
├─ lines-and-columns@1.1.6
├─ load-json-file@1.1.0
├─ loader-runner@2.4.0
├─ locate-path@3.0.0
├─ lodash@4.17.20
├─ loud-rejection@1.6.0
├─ lru-cache@4.1.5
├─ make-dir@2.1.0
├─ map-obj@1.0.1
├─ map-visit@1.0.0
├─ memory-fs@0.4.1
├─ meow@3.7.0
├─ merge-stream@2.0.0
├─ micromatch@3.1.10
├─ miller-rabin@4.0.1
├─ mime-db@1.44.0
├─ mime-types@2.1.27
├─ minimalistic-crypto-utils@1.0.1
├─ minimatch@3.0.4
├─ minimist@1.2.5
├─ minipass-collect@1.0.2
├─ minipass-flush@1.0.5
├─ minipass-pipeline@1.2.4
├─ minizlib@2.1.2
├─ mississippi@3.0.0
├─ mixin-deep@1.3.2
├─ moment-timezone@0.5.31
├─ moment@2.27.0
├─ mousetrap@1.6.5
├─ move-concurrently@1.0.1
├─ ms@2.0.0
├─ nan@2.14.1
├─ nanomatch@1.2.13
├─ neo-async@2.6.2
├─ nice-try@1.0.5
├─ node-fetch@1.7.3
├─ node-gyp@3.8.0
├─ node-libs-browser@2.2.1
├─ node-modules-regexp@1.0.0
├─ node-releases@1.1.60
├─ node-sass@4.14.1
├─ nopt@3.0.6
├─ normalize-package-data@2.5.0
├─ npmlog@4.1.2
├─ number-is-nan@1.0.1
├─ oauth-sign@0.9.0
├─ object-copy@0.1.0
├─ object-inspect@1.8.0
├─ object-is@1.1.2
├─ object-keys@1.1.1
├─ object.entries@1.1.2
├─ os-browserify@0.3.0
├─ os-homedir@1.0.2
├─ os-tmpdir@1.0.2
├─ osenv@0.1.5
├─ p-limit@2.3.0
├─ p-locate@3.0.0
├─ p-map@4.0.0
├─ pako@1.0.11
├─ parallel-transform@1.2.0
├─ parent-module@1.0.1
├─ parse-asn1@5.1.6
├─ parse-json@2.2.0
├─ parse-passwd@1.0.0
├─ pascalcase@0.1.1
├─ path-browserify@0.0.1
├─ path-dirname@1.0.2
├─ path-exists@3.0.0
├─ path-is-absolute@1.0.1
├─ path-key@2.0.1
├─ path-parse@1.0.6
├─ path-type@1.1.0
├─ pegjs@0.10.0
├─ performance-now@2.1.0
├─ phpegjs@1.0.0-beta7
├─ picomatch@2.2.2
├─ pinkie@2.0.4
├─ pirates@4.0.1
├─ posix-character-classes@0.1.1
├─ postcss-modules-extract-imports@2.0.0
├─ postcss-modules-local-by-default@3.0.3
├─ postcss-modules-scope@2.2.0
├─ postcss-modules-values@3.0.0
├─ postcss-selector-parser@6.0.2
├─ process-nextick-args@2.0.1
├─ process@0.11.10
├─ promise@7.3.1
├─ prop-types-exact@1.2.0
├─ prr@1.0.1
├─ pseudomap@1.0.2
├─ psl@1.8.0
├─ public-encrypt@4.0.3
├─ pump@3.0.0
├─ pumpify@1.5.1
├─ qs@6.9.4
├─ querystring-es3@0.2.1
├─ querystring@0.2.0
├─ randomfill@1.0.4
├─ re-resizable@6.5.4
├─ react-addons-shallow-compare@15.6.2
├─ react-dates@17.2.0
├─ react-dom@16.13.1
├─ react-easy-crop@3.1.1
├─ react-is@16.13.1
├─ react-moment-proptypes@1.7.0
├─ react-native-url-polyfill@1.2.0
├─ react-outside-click-handler@1.3.0
├─ react-portal@4.2.1
├─ react-spring@8.0.27
├─ react-use-gesture@7.0.15
├─ react-with-direction@1.3.1
├─ react-with-styles-interface-css@4.0.3
├─ react-with-styles@3.2.3
├─ react@16.13.1
├─ read-pkg-up@1.0.1
├─ read-pkg@1.1.0
├─ readable-stream@2.3.7
├─ readdirp@3.4.0
├─ reakit-system@0.13.1
├─ reakit-warning@0.4.1
├─ reakit@1.1.0
├─ redent@1.0.0
├─ redux-multi@0.1.12
├─ redux-optimist@1.0.0
├─ redux@4.0.5
├─ reflect.ownkeys@0.2.0
├─ regenerate-unicode-properties@8.2.0
├─ regenerator-runtime@0.13.7
├─ regenerator-transform@0.14.5
├─ regexpu-core@4.7.0
├─ regjsgen@0.5.2
├─ regjsparser@0.6.4
├─ remove-trailing-separator@1.1.0
├─ repeat-element@1.1.3
├─ repeating@2.0.1
├─ request@2.88.2
├─ resolve-cwd@2.0.0
├─ resolve-dir@1.0.1
├─ resolve-from@3.0.0
├─ resolve-url@0.2.1
├─ resolve@1.17.0
├─ ret@0.1.15
├─ run-queue@1.0.3
├─ rungen@0.3.2
├─ sass-graph@2.2.5
├─ sass-loader@9.0.3
├─ scheduler@0.19.1
├─ scss-tokenizer@0.2.3
├─ select@1.1.2
├─ set-blocking@2.0.0
├─ set-immediate-shim@1.0.1
├─ set-value@2.0.1
├─ setimmediate@1.0.5
├─ shebang-command@1.2.0
├─ shebang-regex@1.0.0
├─ showdown@1.9.1
├─ simple-html-tokenizer@0.5.9
├─ snapdragon-node@2.1.1
├─ snapdragon-util@3.0.1
├─ source-list-map@2.0.1
├─ source-map-resolve@0.5.3
├─ source-map-url@0.4.0
├─ spdx-correct@3.1.1
├─ spdx-exceptions@2.3.0
├─ speed-measure-webpack-plugin@1.3.3
├─ split-string@3.1.0
├─ sprintf-js@1.1.2
├─ sshpk@1.16.1
├─ ssri@8.0.0
├─ static-extend@0.1.2
├─ stdout-stream@1.4.1
├─ stream-browserify@2.0.2
├─ stream-each@1.2.3
├─ stream-http@2.8.3
├─ string_decoder@1.3.0
├─ string.prototype.trimend@1.0.1
├─ string.prototype.trimstart@1.0.1
├─ strip-bom@2.0.0
├─ strip-indent@1.0.1
├─ style-loader@1.2.1
├─ symbol-observable@1.2.0
├─ tannin@1.2.0
├─ tapable@1.1.3
├─ tar@2.2.2
├─ terser-webpack-plugin@4.1.0
├─ terser@5.2.0
├─ through2@2.0.5
├─ timers-browserify@2.0.11
├─ tiny-emitter@2.1.0
├─ to-arraybuffer@1.0.1
├─ to-fast-properties@2.0.0
├─ to-object-path@0.3.0
├─ to-regex-range@2.1.1
├─ tough-cookie@2.5.0
├─ traverse@0.6.6
├─ trim-newlines@1.0.0
├─ true-case-path@1.0.3
├─ tslib@1.11.2
├─ tty-browserify@0.0.0
├─ tunnel-agent@0.6.0
├─ turbo-combine-reducers@1.0.2
├─ tweetnacl@0.14.5
├─ typedarray@0.0.6
├─ ua-parser-js@0.7.21
├─ unicode-canonical-property-names-ecmascript@1.0.4
├─ unicode-match-property-ecmascript@1.0.4
├─ unicode-match-property-value-ecmascript@1.2.0
├─ unicode-property-aliases-ecmascript@1.1.0
├─ union-value@1.0.1
├─ uniq@1.0.1
├─ unique-slug@2.0.2
├─ unset-value@1.0.0
├─ upath@1.2.0
├─ uri-js@4.2.2
├─ urix@0.1.0
├─ url@0.11.0
├─ use-memo-one@1.1.1
├─ use@3.1.1
├─ util-deprecate@1.0.2
├─ util@0.11.1
├─ v8-compile-cache@2.1.1
├─ validate-npm-package-license@3.0.4
├─ verror@1.10.0
├─ vm-browserify@1.1.2
├─ watchpack-chokidar2@2.0.0
├─ watchpack@1.7.4
├─ webidl-conversions@5.0.0
├─ webpack-cli@3.3.12
├─ webpack-sources@1.4.3
├─ webpack@4.44.1
├─ whatwg-fetch@3.4.0
├─ whatwg-url-without-unicode@8.0.0-3
├─ which@1.3.1
├─ wide-align@1.1.3
├─ worker-farm@1.7.0
├─ wrap-ansi@5.1.0
├─ xtend@4.0.2
├─ yaml@1.10.0
└─ yargs-parser@13.1.2
Done in 10.85s.

All dependencies match the latest package versions :)
yarn install v1.22.4
info No lockfile found.
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@2.1.3: The platform "linux" is incompatible with this module.
info "fsevents@2.1.3" is an optional dependency and failed compatibility check. Excluding it from installation.
info fsevents@1.2.13: The platform "linux" is incompatible with this module.
info "fsevents@1.2.13" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
Done in 6.82s.
yarn upgrade v1.22.4
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@2.1.3: The platform "linux" is incompatible with this module.
info "fsevents@2.1.3" is an optional dependency and failed compatibility check. Excluding it from installation.
info fsevents@1.2.13: The platform "linux" is incompatible with this module.
info "fsevents@1.2.13" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Rebuilding all packages...
success Saved lockfile.
success Saved 444 new dependencies.
info Direct dependencies
├─ @babel/core@7.11.1
├─ @babel/plugin-transform-react-jsx@7.10.4
├─ @babel/plugin-transform-runtime@7.11.0
├─ @babel/preset-env@7.11.0
├─ @babel/register@7.10.5
├─ babel-loader@8.1.0
├─ css-loader@4.2.1
├─ node-sass@4.14.1
├─ sass-loader@9.0.3
├─ speed-measure-webpack-plugin@1.3.3
├─ style-loader@1.2.1
├─ terser-webpack-plugin@4.1.0
├─ webpack-cli@3.3.12
└─ webpack@4.44.1
info All dependencies
├─ @babel/compat-data@7.11.0
├─ @babel/core@7.11.1
├─ @babel/helper-builder-binary-assignment-operator-visitor@7.10.4
├─ @babel/helper-builder-react-jsx-experimental@7.10.5
├─ @babel/helper-builder-react-jsx@7.10.4
├─ @babel/helper-compilation-targets@7.10.4
├─ @babel/helper-define-map@7.10.5
├─ @babel/helper-explode-assignable-expression@7.10.4
├─ @babel/helper-hoist-variables@7.10.4
├─ @babel/helper-member-expression-to-functions@7.11.0
├─ @babel/helper-wrap-function@7.10.4
├─ @babel/helpers@7.10.4
├─ @babel/highlight@7.10.4
├─ @babel/parser@7.11.3
├─ @babel/plugin-proposal-async-generator-functions@7.10.5
├─ @babel/plugin-proposal-class-properties@7.10.4
├─ @babel/plugin-proposal-dynamic-import@7.10.4
├─ @babel/plugin-proposal-export-namespace-from@7.10.4
├─ @babel/plugin-proposal-json-strings@7.10.4
├─ @babel/plugin-proposal-logical-assignment-operators@7.11.0
├─ @babel/plugin-proposal-nullish-coalescing-operator@7.10.4
├─ @babel/plugin-proposal-numeric-separator@7.10.4
├─ @babel/plugin-proposal-optional-catch-binding@7.10.4
├─ @babel/plugin-proposal-optional-chaining@7.11.0
├─ @babel/plugin-proposal-private-methods@7.10.4
├─ @babel/plugin-proposal-unicode-property-regex@7.10.4
├─ @babel/plugin-syntax-class-properties@7.10.4
├─ @babel/plugin-syntax-jsx@7.10.4
├─ @babel/plugin-syntax-top-level-await@7.10.4
├─ @babel/plugin-transform-arrow-functions@7.10.4
├─ @babel/plugin-transform-async-to-generator@7.10.4
├─ @babel/plugin-transform-block-scoped-functions@7.10.4
├─ @babel/plugin-transform-block-scoping@7.11.1
├─ @babel/plugin-transform-classes@7.10.4
├─ @babel/plugin-transform-computed-properties@7.10.4
├─ @babel/plugin-transform-destructuring@7.10.4
├─ @babel/plugin-transform-dotall-regex@7.10.4
├─ @babel/plugin-transform-duplicate-keys@7.10.4
├─ @babel/plugin-transform-exponentiation-operator@7.10.4
├─ @babel/plugin-transform-for-of@7.10.4
├─ @babel/plugin-transform-function-name@7.10.4
├─ @babel/plugin-transform-literals@7.10.4
├─ @babel/plugin-transform-member-expression-literals@7.10.4
├─ @babel/plugin-transform-modules-amd@7.10.5
├─ @babel/plugin-transform-modules-commonjs@7.10.4
├─ @babel/plugin-transform-modules-systemjs@7.10.5
├─ @babel/plugin-transform-modules-umd@7.10.4
├─ @babel/plugin-transform-named-capturing-groups-regex@7.10.4
├─ @babel/plugin-transform-new-target@7.10.4
├─ @babel/plugin-transform-object-super@7.10.4
├─ @babel/plugin-transform-property-literals@7.10.4
├─ @babel/plugin-transform-react-jsx@7.10.4
├─ @babel/plugin-transform-regenerator@7.10.4
├─ @babel/plugin-transform-reserved-words@7.10.4
├─ @babel/plugin-transform-runtime@7.11.0
├─ @babel/plugin-transform-shorthand-properties@7.10.4
├─ @babel/plugin-transform-spread@7.11.0
├─ @babel/plugin-transform-sticky-regex@7.10.4
├─ @babel/plugin-transform-template-literals@7.10.5
├─ @babel/plugin-transform-typeof-symbol@7.10.4
├─ @babel/plugin-transform-unicode-escapes@7.10.4
├─ @babel/plugin-transform-unicode-regex@7.10.4
├─ @babel/preset-env@7.11.0
├─ @babel/preset-modules@0.1.3
├─ @babel/register@7.10.5
├─ @babel/runtime@7.11.2
├─ @npmcli/move-file@1.0.1
├─ @types/json-schema@7.0.5
├─ @types/node@14.6.0
├─ @webassemblyjs/floating-point-hex-parser@1.9.0
├─ @webassemblyjs/helper-code-frame@1.9.0
├─ @webassemblyjs/helper-fsm@1.9.0
├─ @webassemblyjs/helper-wasm-section@1.9.0
├─ @webassemblyjs/wasm-edit@1.9.0
├─ @webassemblyjs/wasm-opt@1.9.0
├─ @xtuc/ieee754@1.2.0
├─ abbrev@1.1.1
├─ acorn@6.4.1
├─ aggregate-error@3.0.1
├─ ajv-errors@1.0.1
├─ ajv-keywords@3.5.2
├─ ajv@6.12.4
├─ amdefine@1.0.1
├─ ansi-styles@3.2.1
├─ anymatch@3.1.1
├─ are-we-there-yet@1.1.5
├─ arr-flatten@1.1.0
├─ array-find-index@1.0.2
├─ asn1.js@5.4.1
├─ asn1@0.2.4
├─ assert@1.5.0
├─ assign-symbols@1.0.0
├─ async-each@1.0.3
├─ async-foreach@0.1.3
├─ asynckit@0.4.0
├─ atob@2.1.2
├─ aws-sign2@0.7.0
├─ aws4@1.10.1
├─ babel-loader@8.1.0
├─ balanced-match@1.0.0
├─ base@0.11.2
├─ base64-js@1.3.1
├─ bcrypt-pbkdf@1.0.2
├─ binary-extensions@2.1.0
├─ block-stream@0.0.9
├─ bluebird@3.7.2
├─ brace-expansion@1.1.11
├─ braces@2.3.2
├─ browserify-aes@1.2.0
├─ browserify-cipher@1.0.1
├─ browserify-des@1.0.2
├─ browserify-rsa@4.0.1
├─ browserify-sign@4.2.1
├─ browserify-zlib@0.2.0
├─ browserslist@4.14.0
├─ buffer-xor@1.0.3
├─ buffer@4.9.2
├─ builtin-status-codes@3.0.0
├─ cacache@15.0.5
├─ cache-base@1.0.1
├─ camelcase-keys@2.1.0
├─ camelcase@6.0.0
├─ caniuse-lite@1.0.30001116
├─ caseless@0.12.0
├─ chokidar@3.4.2
├─ chrome-trace-event@1.0.2
├─ class-utils@0.3.6
├─ clean-stack@2.2.0
├─ cliui@5.0.0
├─ code-point-at@1.1.0
├─ collection-visit@1.0.0
├─ color-convert@1.9.3
├─ color-name@1.1.3
├─ combined-stream@1.0.8
├─ concat-map@0.0.1
├─ concat-stream@1.6.2
├─ console-browserify@1.2.0
├─ console-control-strings@1.1.0
├─ constants-browserify@1.0.0
├─ convert-source-map@1.7.0
├─ copy-concurrently@1.0.5
├─ copy-descriptor@0.1.1
├─ core-js-compat@3.6.5
├─ core-util-is@1.0.2
├─ create-ecdh@4.0.4
├─ create-hmac@1.1.7
├─ cross-spawn@3.0.1
├─ crypto-browserify@3.12.0
├─ css-loader@4.2.1
├─ currently-unhandled@0.4.1
├─ cyclist@1.0.1
├─ dashdash@1.14.1
├─ debug@2.6.9
├─ decamelize@1.2.0
├─ decode-uri-component@0.2.0
├─ define-properties@1.1.3
├─ delayed-stream@1.0.0
├─ delegates@1.0.0
├─ des.js@1.0.1
├─ detect-file@1.0.0
├─ diffie-hellman@5.0.3
├─ domain-browser@1.2.0
├─ duplexify@3.7.1
├─ ecc-jsbn@0.1.2
├─ electron-to-chromium@1.3.536
├─ emoji-regex@7.0.3
├─ enhanced-resolve@4.3.0
├─ errno@0.1.7
├─ error-ex@1.3.2
├─ escalade@3.0.2
├─ escape-string-regexp@1.0.5
├─ eslint-scope@4.0.3
├─ esrecurse@4.2.1
├─ estraverse@4.3.0
├─ esutils@2.0.3
├─ events@3.2.0
├─ expand-brackets@2.1.4
├─ expand-tilde@2.0.2
├─ extend@3.0.2
├─ extglob@2.0.4
├─ extsprintf@1.3.0
├─ fast-deep-equal@3.1.3
├─ fast-json-stable-stringify@2.1.0
├─ fill-range@4.0.0
├─ findup-sync@3.0.0
├─ flush-write-stream@1.1.1
├─ for-in@1.0.2
├─ forever-agent@0.6.1
├─ form-data@2.3.3
├─ from2@2.3.0
├─ fs.realpath@1.0.0
├─ fstream@1.0.12
├─ function-bind@1.1.1
├─ gauge@2.7.4
├─ gaze@1.1.3
├─ gensync@1.0.0-beta.1
├─ get-caller-file@2.0.5
├─ get-value@2.0.6
├─ getpass@0.1.7
├─ glob-parent@5.1.1
├─ global-modules@2.0.0
├─ global-prefix@3.0.0
├─ globule@1.3.2
├─ graceful-fs@4.2.4
├─ har-schema@2.0.0
├─ har-validator@5.1.5
├─ has-ansi@2.0.0
├─ has-symbols@1.0.1
├─ has-unicode@2.0.1
├─ has-value@1.0.0
├─ hash.js@1.1.7
├─ hmac-drbg@1.0.1
├─ hosted-git-info@2.8.8
├─ http-signature@1.2.0
├─ https-browserify@1.0.0
├─ icss-utils@4.1.1
├─ ieee754@1.1.13
├─ import-local@2.0.0
├─ in-publish@2.0.1
├─ indent-string@2.1.0
├─ indexes-of@1.0.1
├─ infer-owner@1.0.4
├─ inflight@1.0.6
├─ ini@1.3.5
├─ interpret@1.4.0
├─ is-accessor-descriptor@1.0.0
├─ is-arrayish@0.2.1
├─ is-binary-path@2.1.0
├─ is-data-descriptor@1.0.0
├─ is-descriptor@1.0.2
├─ is-extglob@2.1.1
├─ is-finite@1.1.0
├─ is-glob@4.0.1
├─ is-plain-object@2.0.4
├─ is-typedarray@1.0.0
├─ is-utf8@0.2.1
├─ is-wsl@1.1.0
├─ isarray@1.0.0
├─ isexe@2.0.0
├─ isstream@0.1.2
├─ jest-worker@26.3.0
├─ js-base64@2.6.4
├─ js-tokens@4.0.0
├─ jsesc@2.5.2
├─ json-parse-better-errors@1.0.2
├─ json-schema-traverse@0.4.1
├─ json-schema@0.2.3
├─ json-stringify-safe@5.0.1
├─ jsprim@1.4.1
├─ kind-of@3.2.2
├─ klona@1.1.2
├─ leven@3.1.0
├─ load-json-file@1.1.0
├─ loader-runner@2.4.0
├─ locate-path@3.0.0
├─ lodash@4.17.20
├─ loose-envify@1.4.0
├─ loud-rejection@1.6.0
├─ lru-cache@4.1.5
├─ make-dir@2.1.0
├─ map-obj@1.0.1
├─ map-visit@1.0.0
├─ memory-fs@0.4.1
├─ meow@3.7.0
├─ merge-stream@2.0.0
├─ micromatch@3.1.10
├─ miller-rabin@4.0.1
├─ mime-db@1.44.0
├─ mime-types@2.1.27
├─ minimalistic-crypto-utils@1.0.1
├─ minimatch@3.0.4
├─ minimist@1.2.5
├─ minipass-collect@1.0.2
├─ minipass-flush@1.0.5
├─ minipass-pipeline@1.2.4
├─ minizlib@2.1.2
├─ mississippi@3.0.0
├─ mixin-deep@1.3.2
├─ move-concurrently@1.0.1
├─ ms@2.0.0
├─ nan@2.14.1
├─ nanomatch@1.2.13
├─ neo-async@2.6.2
├─ nice-try@1.0.5
├─ node-gyp@3.8.0
├─ node-libs-browser@2.2.1
├─ node-modules-regexp@1.0.0
├─ node-releases@1.1.60
├─ node-sass@4.14.1
├─ nopt@3.0.6
├─ normalize-package-data@2.5.0
├─ npmlog@4.1.2
├─ number-is-nan@1.0.1
├─ oauth-sign@0.9.0
├─ object-assign@4.1.1
├─ object-copy@0.1.0
├─ object-keys@1.1.1
├─ object.assign@4.1.0
├─ os-browserify@0.3.0
├─ os-homedir@1.0.2
├─ os-tmpdir@1.0.2
├─ osenv@0.1.5
├─ p-limit@2.3.0
├─ p-locate@3.0.0
├─ p-map@4.0.0
├─ pako@1.0.11
├─ parallel-transform@1.2.0
├─ parse-asn1@5.1.6
├─ parse-json@2.2.0
├─ parse-passwd@1.0.0
├─ pascalcase@0.1.1
├─ path-browserify@0.0.1
├─ path-dirname@1.0.2
├─ path-exists@3.0.0
├─ path-is-absolute@1.0.1
├─ path-key@2.0.1
├─ path-parse@1.0.6
├─ path-type@1.1.0
├─ performance-now@2.1.0
├─ picomatch@2.2.2
├─ pinkie@2.0.4
├─ pirates@4.0.1
├─ posix-character-classes@0.1.1
├─ postcss-modules-extract-imports@2.0.0
├─ postcss-modules-local-by-default@3.0.3
├─ postcss-modules-scope@2.2.0
├─ postcss-modules-values@3.0.0
├─ postcss-selector-parser@6.0.2
├─ process-nextick-args@2.0.1
├─ process@0.11.10
├─ prr@1.0.1
├─ pseudomap@1.0.2
├─ psl@1.8.0
├─ public-encrypt@4.0.3
├─ pump@3.0.0
├─ pumpify@1.5.1
├─ punycode@2.1.1
├─ qs@6.5.2
├─ querystring-es3@0.2.1
├─ querystring@0.2.0
├─ randomfill@1.0.4
├─ read-pkg-up@1.0.1
├─ read-pkg@1.1.0
├─ readable-stream@2.3.7
├─ readdirp@3.4.0
├─ redent@1.0.0
├─ regenerate-unicode-properties@8.2.0
├─ regenerator-runtime@0.13.7
├─ regenerator-transform@0.14.5
├─ regexpu-core@4.7.0
├─ regjsgen@0.5.2
├─ regjsparser@0.6.4
├─ remove-trailing-separator@1.1.0
├─ repeat-element@1.1.3
├─ repeating@2.0.1
├─ request@2.88.2
├─ require-directory@2.1.1
├─ require-main-filename@2.0.0
├─ resolve-cwd@2.0.0
├─ resolve-dir@1.0.1
├─ resolve-from@3.0.0
├─ resolve-url@0.2.1
├─ resolve@1.17.0
├─ ret@0.1.15
├─ run-queue@1.0.3
├─ sass-graph@2.2.5
├─ sass-loader@9.0.3
├─ scss-tokenizer@0.2.3
├─ set-blocking@2.0.0
├─ set-value@2.0.1
├─ setimmediate@1.0.5
├─ sha.js@2.4.11
├─ shebang-command@1.2.0
├─ shebang-regex@1.0.0
├─ snapdragon-node@2.1.1
├─ snapdragon-util@3.0.1
├─ source-list-map@2.0.1
├─ source-map-resolve@0.5.3
├─ source-map-url@0.4.0
├─ spdx-correct@3.1.1
├─ spdx-exceptions@2.3.0
├─ speed-measure-webpack-plugin@1.3.3
├─ split-string@3.1.0
├─ sshpk@1.16.1
├─ ssri@8.0.0
├─ static-extend@0.1.2
├─ stdout-stream@1.4.1
├─ stream-browserify@2.0.2
├─ stream-each@1.2.3
├─ stream-http@2.8.3
├─ string_decoder@1.3.0
├─ strip-bom@2.0.0
├─ strip-indent@1.0.1
├─ style-loader@1.2.1
├─ tapable@1.1.3
├─ tar@2.2.2
├─ terser-webpack-plugin@4.1.0
├─ terser@5.2.0
├─ through2@2.0.5
├─ timers-browserify@2.0.11
├─ to-arraybuffer@1.0.1
├─ to-fast-properties@2.0.0
├─ to-object-path@0.3.0
├─ to-regex-range@2.1.1
├─ tough-cookie@2.5.0
├─ trim-newlines@1.0.0
├─ true-case-path@1.0.3
├─ tslib@1.13.0
├─ tty-browserify@0.0.0
├─ tunnel-agent@0.6.0
├─ tweetnacl@0.14.5
├─ typedarray@0.0.6
├─ unicode-canonical-property-names-ecmascript@1.0.4
├─ unicode-match-property-ecmascript@1.0.4
├─ unicode-match-property-value-ecmascript@1.2.0
├─ unicode-property-aliases-ecmascript@1.1.0
├─ union-value@1.0.1
├─ uniq@1.0.1
├─ unique-slug@2.0.2
├─ unset-value@1.0.0
├─ upath@1.2.0
├─ uri-js@4.2.2
├─ urix@0.1.0
├─ url@0.11.0
├─ use@3.1.1
├─ util-deprecate@1.0.2
├─ util@0.11.1
├─ uuid@3.4.0
├─ v8-compile-cache@2.1.1
├─ validate-npm-package-license@3.0.4
├─ verror@1.10.0
├─ vm-browserify@1.1.2
├─ watchpack-chokidar2@2.0.0
├─ watchpack@1.7.4
├─ webpack-cli@3.3.12
├─ webpack-sources@1.4.3
├─ webpack@4.44.1
├─ which-module@2.0.0
├─ which@1.3.1
├─ wide-align@1.1.3
├─ worker-farm@1.7.0
├─ wrap-ansi@5.1.0
├─ xtend@4.0.2
└─ yargs-parser@13.1.2
Done in 5.48s.
```

### stderr:

```Shell
> TRAVIS_BUILD_DIR=$(cd $(dirname $0); pwd) bash bin/self/package.sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0100   342  100   342    0     0   1401      0 --:--:-- --:--:-- --:--:--  1401
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0100  1239  100  1239    0     0  11162      0 --:--:-- --:--:-- --:--:-- 11162
warning "@wordpress/data > use-memo-one@1.1.1" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/components > react-resize-aware@3.0.1" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/url > react-native-url-polyfill@1.2.0" has unmet peer dependency "react-native@*".
warning "@wordpress/block-editor > react-autosize-textarea@3.0.3" has unmet peer dependency "react@^0.14.0 || ^15.0.0 || ^16.0.0".
warning "@wordpress/block-editor > react-autosize-textarea@3.0.3" has unmet peer dependency "react-dom@^0.14.0 || ^15.0.0 || ^16.0.0".
warning "@wordpress/block-editor > react-spring@8.0.27" has unmet peer dependency "react@>= 16.8.0".
warning "@wordpress/block-editor > react-spring@8.0.27" has unmet peer dependency "react-dom@>= 16.8.0".
warning "@wordpress/block-editor > reakit@1.1.0" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-editor > reakit@1.1.0" has unmet peer dependency "react-dom@^16.8.0".
warning "@wordpress/components > @emotion/core@10.0.34" has unmet peer dependency "react@>=16.3.0".
warning "@wordpress/components > @emotion/native@10.0.27" has unmet peer dependency "react-native@>=0.14.0 <1".
warning "@wordpress/components > @emotion/styled@10.0.27" has unmet peer dependency "react@>=16.3.0".
warning "@wordpress/components > downshift@5.4.7" has unmet peer dependency "react@>=16.8.0".
warning "@wordpress/components > react-dates@17.2.0" has unmet peer dependency "react@^0.14 || ^15.5.4 || ^16.1.1".
warning "@wordpress/components > react-dates@17.2.0" has unmet peer dependency "react-dom@^0.14 || ^15.5.4 || ^16.1.1".
warning "@wordpress/components > react-use-gesture@7.0.15" has unmet peer dependency "react@>= 16.8.0".
warning "@wordpress/components > reakit@1.2.2" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/components > reakit@1.2.2" has unmet peer dependency "react-dom@^16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > reakit > reakit-system@0.13.1" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > reakit > reakit-system@0.13.1" has unmet peer dependency "react-dom@^16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > reakit > reakit-utils@0.13.1" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > reakit > reakit-utils@0.13.1" has unmet peer dependency "react-dom@^16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > reakit > reakit-warning@0.4.1" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > @emotion/native > @emotion/primitives-core@10.0.27" has unmet peer dependency "react@>=16.3.0".
warning "@wordpress/block-directory > @wordpress/components > @emotion/styled > @emotion/styled-base@10.0.31" has unmet peer dependency "react@>=16.3.0".
warning "@wordpress/block-directory > @wordpress/components > react-dates > airbnb-prop-types@2.16.0" has unmet peer dependency "react@^0.14 || ^15.0.0 || ^16.0.0-alpha".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-outside-click-handler@1.3.0" has unmet peer dependency "react@^0.14 || >=15".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-outside-click-handler@1.3.0" has unmet peer dependency "react-dom@^0.14 || >=15".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-portal@4.2.1" has unmet peer dependency "react@^15.0.0-0 || ^16.0.0-0 || ^17.0.0-0".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-with-styles@3.2.3" has unmet peer dependency "react@>=0.14".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-with-styles@3.2.3" has unmet peer dependency "react-with-direction@^1.1.0".
warning "@wordpress/block-directory > @wordpress/components > reakit > reakit-system@0.14.2" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > reakit > reakit-system@0.14.2" has unmet peer dependency "react-dom@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > reakit > reakit-utils@0.14.2" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > reakit > reakit-utils@0.14.2" has unmet peer dependency "react-dom@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > reakit > reakit-warning@0.5.2" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-library > react-easy-crop@3.1.1" has unmet peer dependency "react@>=16.4.0".
warning "@wordpress/block-library > react-easy-crop@3.1.1" has unmet peer dependency "react-dom@>=16.4.0".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-with-styles > react-with-direction@1.3.1" has unmet peer dependency "react@^0.14 || ^15 || ^16".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-with-styles > react-with-direction@1.3.1" has unmet peer dependency "react-dom@^0.14 || ^15 || ^16".
npx: installed 300 in 12.681s

warning @wordpress/block-directory > @wordpress/components > react-dates > react-addons-shallow-compare > fbjs > core-js@1.2.7: core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.
warning node-sass > request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
warning node-sass > node-gyp > request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
warning node-sass > request > har-validator@5.1.5: this library is no longer supported
warning webpack > watchpack > watchpack-chokidar2 > chokidar@2.1.8: Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.
warning webpack > watchpack > watchpack-chokidar2 > chokidar > fsevents@1.2.13: fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.
warning webpack > micromatch > snapdragon > source-map-resolve > resolve-url@0.2.1: https://github.com/lydell/resolve-url#deprecated
warning webpack > micromatch > snapdragon > source-map-resolve > urix@0.1.0: Please see https://github.com/lydell/urix#deprecated
warning "@wordpress/annotations > @wordpress/data > use-memo-one@1.1.1" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > react-resize-aware@3.0.1" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/api-fetch > @wordpress/url > react-native-url-polyfill@1.2.0" has unmet peer dependency "react-native@*".
warning "@wordpress/block-directory > @wordpress/components > @emotion/core@10.0.35" has unmet peer dependency "react@>=16.3.0".
warning "@wordpress/block-directory > @wordpress/components > @emotion/native@10.0.27" has unmet peer dependency "react-native@>=0.14.0 <1".
warning "@wordpress/block-directory > @wordpress/components > downshift@5.4.7" has unmet peer dependency "react@>=16.8.0".
warning "@wordpress/block-directory > @wordpress/components > @emotion/styled@10.0.27" has unmet peer dependency "react@>=16.3.0".
warning "@wordpress/block-directory > @wordpress/components > react-dates@17.2.0" has unmet peer dependency "react@^0.14 || ^15.5.4 || ^16.1.1".
warning "@wordpress/block-directory > @wordpress/components > react-dates@17.2.0" has unmet peer dependency "react-dom@^0.14 || ^15.5.4 || ^16.1.1".
warning "@wordpress/block-directory > @wordpress/components > react-use-gesture@7.0.15" has unmet peer dependency "react@>= 16.8.0".
warning "@wordpress/block-directory > @wordpress/components > reakit@1.2.2" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > reakit@1.2.2" has unmet peer dependency "react-dom@^16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > reakit@1.1.0" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > reakit@1.1.0" has unmet peer dependency "react-dom@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > react-spring@8.0.27" has unmet peer dependency "react@>= 16.8.0".
warning "@wordpress/block-directory > @wordpress/components > react-spring@8.0.27" has unmet peer dependency "react-dom@>= 16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > react-autosize-textarea@3.0.3" has unmet peer dependency "react@^0.14.0 || ^15.0.0 || ^16.0.0".
warning "@wordpress/block-directory > @wordpress/block-editor > react-autosize-textarea@3.0.3" has unmet peer dependency "react-dom@^0.14.0 || ^15.0.0 || ^16.0.0".
warning "@wordpress/block-directory > @wordpress/edit-post > @wordpress/block-library > react-easy-crop@3.1.1" has unmet peer dependency "react@>=16.4.0".
warning "@wordpress/block-directory > @wordpress/edit-post > @wordpress/block-library > react-easy-crop@3.1.1" has unmet peer dependency "react-dom@>=16.4.0".
warning "@wordpress/block-directory > @wordpress/components > @emotion/native > @emotion/primitives-core@10.0.27" has unmet peer dependency "react@>=16.3.0".
warning "@wordpress/block-directory > @wordpress/components > react-dates > airbnb-prop-types@2.16.0" has unmet peer dependency "react@^0.14 || ^15.0.0 || ^16.0.0-alpha".
warning "@wordpress/block-directory > @wordpress/components > @emotion/styled > @emotion/styled-base@10.0.31" has unmet peer dependency "react@>=16.3.0".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-outside-click-handler@1.3.0" has unmet peer dependency "react@^0.14 || >=15".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-outside-click-handler@1.3.0" has unmet peer dependency "react-dom@^0.14 || >=15".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-portal@4.2.1" has unmet peer dependency "react@^15.0.0-0 || ^16.0.0-0 || ^17.0.0-0".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-with-styles@3.2.3" has unmet peer dependency "react@>=0.14".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-with-styles@3.2.3" has unmet peer dependency "react-with-direction@^1.1.0".
warning "@wordpress/block-directory > @wordpress/components > reakit > reakit-system@0.14.2" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > reakit > reakit-system@0.14.2" has unmet peer dependency "react-dom@^16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > reakit > reakit-system@0.13.1" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > reakit > reakit-system@0.13.1" has unmet peer dependency "react-dom@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > reakit > reakit-utils@0.14.2" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > reakit > reakit-utils@0.14.2" has unmet peer dependency "react-dom@^16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > reakit > reakit-utils@0.13.1" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > reakit > reakit-utils@0.13.1" has unmet peer dependency "react-dom@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > reakit > reakit-warning@0.5.2" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > reakit > reakit-warning@0.4.1" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-with-styles > react-with-direction@1.3.1" has unmet peer dependency "react@^0.14 || ^15 || ^16".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-with-styles > react-with-direction@1.3.1" has unmet peer dependency "react-dom@^0.14 || ^15 || ^16".
warning @wordpress/block-directory > @wordpress/components > react-dates > react-addons-shallow-compare > fbjs > core-js@1.2.7: core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.
warning node-sass > request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
warning node-sass > node-gyp > request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
warning node-sass > request > har-validator@5.1.5: this library is no longer supported
warning webpack > watchpack > watchpack-chokidar2 > chokidar@2.1.8: Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.
warning webpack > watchpack > watchpack-chokidar2 > chokidar > fsevents@1.2.13: fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.
warning webpack > micromatch > snapdragon > source-map-resolve > urix@0.1.0: Please see https://github.com/lydell/urix#deprecated
warning webpack > micromatch > snapdragon > source-map-resolve > resolve-url@0.2.1: https://github.com/lydell/resolve-url#deprecated
warning "@wordpress/annotations > @wordpress/data > use-memo-one@1.1.1" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > react-resize-aware@3.0.1" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/api-fetch > @wordpress/url > react-native-url-polyfill@1.2.0" has unmet peer dependency "react-native@*".
warning "@wordpress/block-directory > @wordpress/block-editor > reakit@1.1.0" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > reakit@1.1.0" has unmet peer dependency "react-dom@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > reakit@1.2.2" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > reakit@1.2.2" has unmet peer dependency "react-dom@^16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > react-spring@8.0.27" has unmet peer dependency "react@>= 16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > react-spring@8.0.27" has unmet peer dependency "react-dom@>= 16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > react-autosize-textarea@3.0.3" has unmet peer dependency "react@^0.14.0 || ^15.0.0 || ^16.0.0".
warning "@wordpress/block-directory > @wordpress/block-editor > react-autosize-textarea@3.0.3" has unmet peer dependency "react-dom@^0.14.0 || ^15.0.0 || ^16.0.0".
warning "@wordpress/block-directory > @wordpress/components > @emotion/core@10.0.35" has unmet peer dependency "react@>=16.3.0".
warning "@wordpress/block-directory > @wordpress/components > @emotion/styled@10.0.27" has unmet peer dependency "react@>=16.3.0".
warning "@wordpress/block-directory > @wordpress/components > @emotion/native@10.0.27" has unmet peer dependency "react-native@>=0.14.0 <1".
warning "@wordpress/block-directory > @wordpress/components > downshift@5.4.7" has unmet peer dependency "react@>=16.8.0".
warning "@wordpress/block-directory > @wordpress/components > react-use-gesture@7.0.15" has unmet peer dependency "react@>= 16.8.0".
warning "@wordpress/block-directory > @wordpress/components > react-dates@17.2.0" has unmet peer dependency "react@^0.14 || ^15.5.4 || ^16.1.1".
warning "@wordpress/block-directory > @wordpress/components > react-dates@17.2.0" has unmet peer dependency "react-dom@^0.14 || ^15.5.4 || ^16.1.1".
warning "@wordpress/block-directory > @wordpress/edit-post > @wordpress/block-library > react-easy-crop@3.1.1" has unmet peer dependency "react@>=16.4.0".
warning "@wordpress/block-directory > @wordpress/edit-post > @wordpress/block-library > react-easy-crop@3.1.1" has unmet peer dependency "react-dom@>=16.4.0".
warning "@wordpress/block-directory > @wordpress/block-editor > reakit > reakit-system@0.13.1" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > reakit > reakit-system@0.13.1" has unmet peer dependency "react-dom@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > reakit > reakit-system@0.14.2" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > reakit > reakit-system@0.14.2" has unmet peer dependency "react-dom@^16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > reakit > reakit-utils@0.13.1" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > reakit > reakit-utils@0.13.1" has unmet peer dependency "react-dom@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > reakit > reakit-utils@0.14.2" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > reakit > reakit-utils@0.14.2" has unmet peer dependency "react-dom@^16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > reakit > reakit-warning@0.4.1" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > reakit > reakit-warning@0.5.2" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > @emotion/styled > @emotion/styled-base@10.0.31" has unmet peer dependency "react@>=16.3.0".
warning "@wordpress/block-directory > @wordpress/components > @emotion/native > @emotion/primitives-core@10.0.27" has unmet peer dependency "react@>=16.3.0".
warning "@wordpress/block-directory > @wordpress/components > react-dates > airbnb-prop-types@2.16.0" has unmet peer dependency "react@^0.14 || ^15.0.0 || ^16.0.0-alpha".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-portal@4.2.1" has unmet peer dependency "react@^15.0.0-0 || ^16.0.0-0 || ^17.0.0-0".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-outside-click-handler@1.3.0" has unmet peer dependency "react@^0.14 || >=15".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-outside-click-handler@1.3.0" has unmet peer dependency "react-dom@^0.14 || >=15".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-with-styles@3.2.3" has unmet peer dependency "react@>=0.14".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-with-styles@3.2.3" has unmet peer dependency "react-with-direction@^1.1.0".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-with-styles > react-with-direction@1.3.1" has unmet peer dependency "react@^0.14 || ^15 || ^16".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-with-styles > react-with-direction@1.3.1" has unmet peer dependency "react-dom@^0.14 || ^15 || ^16".
npx: installed 300 in 7.266s

warning node-sass > request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
warning node-sass > node-gyp > request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
warning node-sass > request > har-validator@5.1.5: this library is no longer supported
warning webpack > watchpack > watchpack-chokidar2 > chokidar@2.1.8: Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.
warning webpack > watchpack > watchpack-chokidar2 > chokidar > fsevents@1.2.13: fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.
warning webpack > micromatch > snapdragon > source-map-resolve > resolve-url@0.2.1: https://github.com/lydell/resolve-url#deprecated
warning webpack > micromatch > snapdragon > source-map-resolve > urix@0.1.0: Please see https://github.com/lydell/urix#deprecated
warning node-sass > request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
warning node-sass > node-gyp > request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
warning node-sass > request > har-validator@5.1.5: this library is no longer supported
warning webpack > watchpack > watchpack-chokidar2 > chokidar@2.1.8: Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.
warning webpack > watchpack > watchpack-chokidar2 > chokidar > fsevents@1.2.13: fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.
warning webpack > micromatch > snapdragon > source-map-resolve > urix@0.1.0: Please see https://github.com/lydell/urix#deprecated
warning webpack > micromatch > snapdragon > source-map-resolve > resolve-url@0.2.1: https://github.com/lydell/resolve-url#deprecated
```

</details>

</details>

## Changed files
<details>
<summary>Changed 2 files: </summary>

- gh-pages/gutenberg/yarn.lock
- gh-pages/page/yarn.lock

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)