### PR TITLE
release: v0.2.3

### DIFF
--- a/gh-pages/gutenberg/package.json
+++ b/gh-pages/gutenberg/package.json
@@ -71,7 +71,7 @@
     "sass-loader": "^10.0.2",
     "speed-measure-webpack-plugin": "^1.3.3",
     "style-loader": "^1.2.1",
-    "terser-webpack-plugin": "^4.1.0",
+    "terser-webpack-plugin": "^4.2.1",
     "webpack": "^4.44.1",
     "webpack-cli": "^3.3.12"
   }

--- a/gh-pages/gutenberg/yarn.lock
+++ b/gh-pages/gutenberg/yarn.lock
@@ -1042,9 +1042,9 @@
   integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
 
 "@types/node@*":
-  version "14.6.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.6.4.tgz#a145cc0bb14ef9c4777361b7bbafa5cf8e3acb5a"
-  integrity sha512-Wk7nG1JSaMfMpoMJDKUsWYugliB2Vy55pdjLpmLixeyMi7HizW2I/9QoxsPCkXl3dO+ZOVqPumKaDUv5zJu2uQ==
+  version "14.10.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.10.2.tgz#9b47a2c8e4dabd4db73b57e750b24af689600514"
+  integrity sha512-IzMhbDYCpv26pC2wboJ4MMOa9GKtjplXfcAqrMeNJpUUwpM/2ATt2w1JPUXwS6spu856TvKZL2AOmeU2rAxskw==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -1989,9 +1989,9 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.4.1, ajv-keywords@^3.5.2:
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
 
 ajv@^6.1.0, ajv@^6.10.2, ajv@^6.12.3, ajv@^6.12.4:
-  version "6.12.4"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.4.tgz#0614facc4522127fa713445c6bfd3ebd376e2234"
-  integrity sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==
+  version "6.12.5"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.5.tgz#19b0e8bae8f476e5ba666300387775fb1a00a4da"
+  integrity sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==
   dependencies:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
@@ -2298,9 +2298,9 @@ bn.js@^5.1.1:
   integrity sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==
 
 body-scroll-lock@^3.0.2, body-scroll-lock@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/body-scroll-lock/-/body-scroll-lock-3.1.3.tgz#cf78cc04d82328bb54276e104bda66dc93cb3695"
-  integrity sha512-KMV9MT96y2PFUL2C98e2nx/Gs2mhCAzYP6Gsu/9r7Rhn27qxu1yTnQBqHogUuvwVSbstEHNXTaToPNsL7oBZ9g==
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/body-scroll-lock/-/body-scroll-lock-3.1.5.tgz#c1392d9217ed2c3e237fee1e910f6cdd80b7aaec"
+  integrity sha512-Yi1Xaml0EvNA0OYWxXiYNqY24AfWkbA6w5vxE7GWxtKfzIbZM+Qw+aSmkgsbWzbHiy/RCSkUZBplVxTA+E4jJg==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -2405,14 +2405,14 @@ browserify-zlib@^0.2.0:
     pako "~1.0.5"
 
 browserslist@^4.12.0, browserslist@^4.8.5:
-  version "4.14.1"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.14.1.tgz#cb2b490ba881d45dc3039078c7ed04411eaf3fa3"
-  integrity sha512-zyBTIHydW37pnb63c7fHFXUG6EcqWOqoMdDx6cdyaDFriZ20EoVxcE95S54N+heRqY8m8IUgB5zYta/gCwSaaA==
+  version "4.14.2"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.14.2.tgz#1b3cec458a1ba87588cc5e9be62f19b6d48813ce"
+  integrity sha512-HI4lPveGKUR0x2StIz+2FXfDk9SfVMrxn6PLh1JeGUwcuoDkdKZebWiyLRJ68iIPDpMI4JLVDf7S7XzslgWOhw==
   dependencies:
-    caniuse-lite "^1.0.30001124"
-    electron-to-chromium "^1.3.562"
+    caniuse-lite "^1.0.30001125"
+    electron-to-chromium "^1.3.564"
     escalade "^3.0.2"
-    node-releases "^1.1.60"
+    node-releases "^1.1.61"
 
 buffer-from@^1.0.0:
   version "1.1.1"
@@ -2538,10 +2538,10 @@ camelize@^1.0.0:
   resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.0.tgz#164a5483e630fa4321e5af07020e531831b2609b"
   integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
-caniuse-lite@^1.0.30001124:
-  version "1.0.30001124"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001124.tgz#5d9998190258e11630d674fc50ea8e579ae0ced2"
-  integrity sha512-zQW8V3CdND7GHRH6rxm6s59Ww4g/qGWTheoboW9nfeMg7sUoopIfKCcNZUjwYRCOrvereh3kwDpZj4VLQ7zGtA==
+caniuse-lite@^1.0.30001125:
+  version "1.0.30001131"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001131.tgz#afad8a28fc2b7a0d3ae9407e71085a0ead905d54"
+  integrity sha512-4QYi6Mal4MMfQMSqGIRPGbKIbZygeN83QsWq1ixpUwvtfgAZot5BrCKzGygvZaV+CnELdTwD0S4cqUNozq7/Cw==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -3105,10 +3105,10 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-electron-to-chromium@^1.3.562:
-  version "1.3.564"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.564.tgz#e9c319ae437b3eb8bbf3e3bae4bead5a21945961"
-  integrity sha512-fNaYN3EtKQWLQsrKXui8mzcryJXuA0LbCLoizeX6oayG2emBaS5MauKjCPAvc29NEY4FpLHIUWiP+Y0Bfrs5dg==
+electron-to-chromium@^1.3.564:
+  version "1.3.568"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.568.tgz#0fa28cd3e5cbd9e8c66f72309eef0646f65a5b66"
+  integrity sha512-j9MlEwgTHVW/lq93Hw8yhzA886oLjDm3Hz7eDkWP2v4fzLVuqOWhpNluziSnmR/tBqgoYldagbLknrdg+B7Tlw==
 
 elliptic@^6.5.3:
   version "6.5.3"
@@ -3192,6 +3192,24 @@ es-abstract@^1.17.0-next.1, es-abstract@^1.17.4, es-abstract@^1.17.5:
     string.prototype.trimend "^1.0.1"
     string.prototype.trimstart "^1.0.1"
 
+es-abstract@^1.18.0-next.0:
+  version "1.18.0-next.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.18.0-next.0.tgz#b302834927e624d8e5837ed48224291f2c66e6fc"
+  integrity sha512-elZXTZXKn51hUBdJjSZGYRujuzilgXo8vSPQzjGYXLvSlGiCo8VO8ZGV3kjo9a0WNJJ57hENagwbtlRuHuzkcQ==
+  dependencies:
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
+    is-callable "^1.2.0"
+    is-negative-zero "^2.0.0"
+    is-regex "^1.1.1"
+    object-inspect "^1.8.0"
+    object-keys "^1.1.1"
+    object.assign "^4.1.0"
+    string.prototype.trimend "^1.0.1"
+    string.prototype.trimstart "^1.0.1"
+
 es-to-primitive@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.1.tgz#e55cd4c9cdc188bcefb03b366c736323fc5c898a"
@@ -3202,9 +3220,9 @@ es-to-primitive@^1.2.1:
     is-symbol "^1.0.2"
 
 escalade@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.0.2.tgz#6a580d70edb87880f22b4c91d0d56078df6962c4"
-  integrity sha512-gPYAU37hYCUhW5euPeR+Y74F7BL+IBsV93j5cvGriSaD1aG6MGsqsV1yamRdrWrb2j3aiZvb0X+UBOWpx3JWtQ==
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.0.tgz#e8e2d7c7a8b76f6ee64c2181d6b8151441602d4e"
+  integrity sha512-mAk+hPSO8fLDkhV7V0dXazH5pDc6MrjBTPyD3VeKzxnVFjH1MIxbCdqGZB9O8+EwWakZs3ZCbDS4IpRt79V1ig==
 
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -3733,7 +3751,7 @@ has-flag@^4.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
-has-symbols@^1.0.0, has-symbols@^1.0.1:
+has-symbols@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
   integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
@@ -4001,9 +4019,9 @@ is-buffer@^1.1.5:
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
 is-callable@^1.1.4, is-callable@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.0.tgz#83336560b54a38e35e3a2df7afd0454d691468bb"
-  integrity sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.1.tgz#4d1e21a4f437509d25ce55f8184350771421c96d"
+  integrity sha512-wliAfSzx6V+6WfMOmus1xy0XvSgf/dlStkvTfq7F0g4bOIW0PSUbnyse3NhDwdyYS1ozfUtAAySqTws3z9Eqgg==
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
@@ -4090,6 +4108,11 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
+is-negative-zero@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.0.tgz#9553b121b0fac28869da9ed459e20c7543788461"
+  integrity sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=
+
 is-number@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
@@ -4114,7 +4137,7 @@ is-promise@^4.0.0:
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-4.0.0.tgz#42ff9f84206c1991d26debf520dd5c01042dd2f3"
   integrity sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==
 
-is-regex@^1.1.0:
+is-regex@^1.1.0, is-regex@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.1.tgz#c6f98aacc546f6cec5468a07b7b153ab564a57b9"
   integrity sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==
@@ -4661,9 +4684,9 @@ moment-timezone@^0.5.16:
     moment ">= 2.9.0"
 
 "moment@>= 2.9.0", moment@>=1.6.0, moment@^2.22.1:
-  version "2.27.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.27.0.tgz#8bff4e3e26a236220dfe3e36de756b6ebaa0105d"
-  integrity sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==
+  version "2.28.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.28.0.tgz#cdfe73ce01327cee6537b0fafac2e0f21a237d75"
+  integrity sha512-Z5KOjYmnHyd/ukynmFd/WwyXHd7L4J9vTI/nn5Ap9AVUgaAE15VvQ9MOGmJJygEUklupqIrFnor/tjTwRU+tQw==
 
 mousetrap@^1.6.5:
   version "1.6.5"
@@ -4784,7 +4807,7 @@ node-modules-regexp@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
-node-releases@^1.1.60:
+node-releases@^1.1.61:
   version "1.1.61"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.61.tgz#707b0fca9ce4e11783612ba4a2fcba09047af16e"
   integrity sha512-DD5vebQLg8jLCOzwupn954fbIiZht05DAZs0k2u8NStSe6h9XdsuIQL8hSRKYiU8WUQRznmSDrKGbv3ObOmC7g==
@@ -4875,7 +4898,7 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-inspect@^1.7.0:
+object-inspect@^1.7.0, object-inspect@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.8.0.tgz#df807e5ecf53a609cc6bfe93eac3cc7be5b3a9d0"
   integrity sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==
@@ -4888,7 +4911,7 @@ object-is@^1.1.2:
     define-properties "^1.1.3"
     es-abstract "^1.17.5"
 
-object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.1:
+object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
@@ -4901,14 +4924,14 @@ object-visit@^1.0.0:
     isobject "^3.0.0"
 
 object.assign@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
-  integrity sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.1.tgz#303867a666cdd41936ecdedfb1f8f3e32a478cdd"
+  integrity sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==
   dependencies:
-    define-properties "^1.1.2"
-    function-bind "^1.1.1"
-    has-symbols "^1.0.0"
-    object-keys "^1.0.11"
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.0"
+    has-symbols "^1.0.1"
+    object-keys "^1.1.1"
 
 object.entries@^1.1.2:
   version "1.1.2"
@@ -6039,6 +6062,13 @@ serialize-javascript@^4.0.0:
   dependencies:
     randombytes "^2.1.0"
 
+serialize-javascript@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-5.0.1.tgz#7886ec848049a462467a97d3d918ebb2aaf934f4"
+  integrity sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==
+  dependencies:
+    randombytes "^2.1.0"
+
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
@@ -6476,19 +6506,19 @@ terser-webpack-plugin@^1.4.3:
     webpack-sources "^1.4.0"
     worker-farm "^1.7.0"
 
-terser-webpack-plugin@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-4.1.0.tgz#6e9d6ae4e1a900d88ddce8da6a47507ea61f44bc"
-  integrity sha512-0ZWDPIP8BtEDZdChbufcXUigOYk6dOX/P/X0hWxqDDcVAQLb8Yy/0FAaemSfax3PAA67+DJR778oz8qVbmy4hA==
+terser-webpack-plugin@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-4.2.1.tgz#44b88ef4d7443129fb136a68b5ec3e80d63ec471"
+  integrity sha512-D0IZQNl1ZN/JivFNDFzOeU2Bk2LdQQESHJhKTHsodpUmISkaeRwVFk7gzHzX4OuQwanDGelOxIEsBt1SZ+s6nA==
   dependencies:
     cacache "^15.0.5"
     find-cache-dir "^3.3.1"
     jest-worker "^26.3.0"
     p-limit "^3.0.2"
-    schema-utils "^2.6.6"
-    serialize-javascript "^4.0.0"
+    schema-utils "^2.7.1"
+    serialize-javascript "^5.0.1"
     source-map "^0.6.1"
-    terser "^5.0.0"
+    terser "^5.3.1"
     webpack-sources "^1.4.3"
 
 terser@^4.1.2:
@@ -6500,10 +6530,10 @@ terser@^4.1.2:
     source-map "~0.6.1"
     source-map-support "~0.5.12"
 
-terser@^5.0.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.3.0.tgz#c481f4afecdcc182d5e2bdd2ff2dc61555161e81"
-  integrity sha512-XTT3D3AwxC54KywJijmY2mxZ8nJiEjBHVYzq8l9OaYuRFWeQNBwvipuzzYEP4e+/AVcd1hqG/CqgsdIRyT45Fg==
+terser@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.3.1.tgz#f50fe20ab48b15234fe9bdd86b10148ad5fca787"
+  integrity sha512-yD80f4hdwCWTH5mojzxe1q8bN1oJbsK/vfJGLcPZM/fl+/jItIVNKhFIHqqR71OipFWMLgj3Kc+GIp6CeIqfnA==
   dependencies:
     commander "^2.20.0"
     source-map "~0.6.1"
@@ -6639,9 +6669,9 @@ typedarray@^0.0.6:
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
 ua-parser-js@^0.7.18:
-  version "0.7.21"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.21.tgz#853cf9ce93f642f67174273cc34565ae6f308777"
-  integrity sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==
+  version "0.7.22"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.22.tgz#960df60a5f911ea8f1c818f3747b99c6e177eae3"
+  integrity sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"

--- a/gh-pages/page/package.json
+++ b/gh-pages/page/package.json
@@ -20,7 +20,7 @@
     "sass-loader": "^10.0.2",
     "speed-measure-webpack-plugin": "^1.3.3",
     "style-loader": "^1.2.1",
-    "terser-webpack-plugin": "^4.1.0",
+    "terser-webpack-plugin": "^4.2.1",
     "webpack": "^4.44.1",
     "webpack-cli": "^3.3.12"
   }

--- a/gh-pages/page/yarn.lock
+++ b/gh-pages/page/yarn.lock
@@ -896,9 +896,9 @@
   integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
 
 "@types/node@*":
-  version "14.6.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.6.4.tgz#a145cc0bb14ef9c4777361b7bbafa5cf8e3acb5a"
-  integrity sha512-Wk7nG1JSaMfMpoMJDKUsWYugliB2Vy55pdjLpmLixeyMi7HizW2I/9QoxsPCkXl3dO+ZOVqPumKaDUv5zJu2uQ==
+  version "14.10.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.10.2.tgz#9b47a2c8e4dabd4db73b57e750b24af689600514"
+  integrity sha512-IzMhbDYCpv26pC2wboJ4MMOa9GKtjplXfcAqrMeNJpUUwpM/2ATt2w1JPUXwS6spu856TvKZL2AOmeU2rAxskw==
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
@@ -1084,9 +1084,9 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.4.1, ajv-keywords@^3.5.2:
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
 
 ajv@^6.1.0, ajv@^6.10.2, ajv@^6.12.3, ajv@^6.12.4:
-  version "6.12.4"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.4.tgz#0614facc4522127fa713445c6bfd3ebd376e2234"
-  integrity sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==
+  version "6.12.5"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.5.tgz#19b0e8bae8f476e5ba666300387775fb1a00a4da"
+  integrity sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==
   dependencies:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
@@ -1434,14 +1434,14 @@ browserify-zlib@^0.2.0:
     pako "~1.0.5"
 
 browserslist@^4.12.0, browserslist@^4.8.5:
-  version "4.14.1"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.14.1.tgz#cb2b490ba881d45dc3039078c7ed04411eaf3fa3"
-  integrity sha512-zyBTIHydW37pnb63c7fHFXUG6EcqWOqoMdDx6cdyaDFriZ20EoVxcE95S54N+heRqY8m8IUgB5zYta/gCwSaaA==
+  version "4.14.2"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.14.2.tgz#1b3cec458a1ba87588cc5e9be62f19b6d48813ce"
+  integrity sha512-HI4lPveGKUR0x2StIz+2FXfDk9SfVMrxn6PLh1JeGUwcuoDkdKZebWiyLRJ68iIPDpMI4JLVDf7S7XzslgWOhw==
   dependencies:
-    caniuse-lite "^1.0.30001124"
-    electron-to-chromium "^1.3.562"
+    caniuse-lite "^1.0.30001125"
+    electron-to-chromium "^1.3.564"
     escalade "^3.0.2"
-    node-releases "^1.1.60"
+    node-releases "^1.1.61"
 
 buffer-from@^1.0.0:
   version "1.1.1"
@@ -1549,10 +1549,10 @@ camelcase@^6.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.0.0.tgz#5259f7c30e35e278f1bdc2a4d91230b37cad981e"
   integrity sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==
 
-caniuse-lite@^1.0.30001124:
-  version "1.0.30001124"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001124.tgz#5d9998190258e11630d674fc50ea8e579ae0ced2"
-  integrity sha512-zQW8V3CdND7GHRH6rxm6s59Ww4g/qGWTheoboW9nfeMg7sUoopIfKCcNZUjwYRCOrvereh3kwDpZj4VLQ7zGtA==
+caniuse-lite@^1.0.30001125:
+  version "1.0.30001131"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001131.tgz#afad8a28fc2b7a0d3ae9407e71085a0ead905d54"
+  integrity sha512-4QYi6Mal4MMfQMSqGIRPGbKIbZygeN83QsWq1ixpUwvtfgAZot5BrCKzGygvZaV+CnELdTwD0S4cqUNozq7/Cw==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -1909,7 +1909,7 @@ decode-uri-component@^0.2.0:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
-define-properties@^1.1.2:
+define-properties@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
   integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
@@ -1993,10 +1993,10 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-electron-to-chromium@^1.3.562:
-  version "1.3.564"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.564.tgz#e9c319ae437b3eb8bbf3e3bae4bead5a21945961"
-  integrity sha512-fNaYN3EtKQWLQsrKXui8mzcryJXuA0LbCLoizeX6oayG2emBaS5MauKjCPAvc29NEY4FpLHIUWiP+Y0Bfrs5dg==
+electron-to-chromium@^1.3.564:
+  version "1.3.568"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.568.tgz#0fa28cd3e5cbd9e8c66f72309eef0646f65a5b66"
+  integrity sha512-j9MlEwgTHVW/lq93Hw8yhzA886oLjDm3Hz7eDkWP2v4fzLVuqOWhpNluziSnmR/tBqgoYldagbLknrdg+B7Tlw==
 
 elliptic@^6.5.3:
   version "6.5.3"
@@ -2051,10 +2051,54 @@ error-ex@^1.2.0:
   dependencies:
     is-arrayish "^0.2.1"
 
+es-abstract@^1.17.5:
+  version "1.17.6"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.6.tgz#9142071707857b2cacc7b89ecb670316c3e2d52a"
+  integrity sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==
+  dependencies:
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
+    is-callable "^1.2.0"
+    is-regex "^1.1.0"
+    object-inspect "^1.7.0"
+    object-keys "^1.1.1"
+    object.assign "^4.1.0"
+    string.prototype.trimend "^1.0.1"
+    string.prototype.trimstart "^1.0.1"
+
+es-abstract@^1.18.0-next.0:
+  version "1.18.0-next.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.18.0-next.0.tgz#b302834927e624d8e5837ed48224291f2c66e6fc"
+  integrity sha512-elZXTZXKn51hUBdJjSZGYRujuzilgXo8vSPQzjGYXLvSlGiCo8VO8ZGV3kjo9a0WNJJ57hENagwbtlRuHuzkcQ==
+  dependencies:
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
+    is-callable "^1.2.0"
+    is-negative-zero "^2.0.0"
+    is-regex "^1.1.1"
+    object-inspect "^1.8.0"
+    object-keys "^1.1.1"
+    object.assign "^4.1.0"
+    string.prototype.trimend "^1.0.1"
+    string.prototype.trimstart "^1.0.1"
+
+es-to-primitive@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.1.tgz#e55cd4c9cdc188bcefb03b366c736323fc5c898a"
+  integrity sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==
+  dependencies:
+    is-callable "^1.1.4"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.2"
+
 escalade@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.0.2.tgz#6a580d70edb87880f22b4c91d0d56078df6962c4"
-  integrity sha512-gPYAU37hYCUhW5euPeR+Y74F7BL+IBsV93j5cvGriSaD1aG6MGsqsV1yamRdrWrb2j3aiZvb0X+UBOWpx3JWtQ==
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.0.tgz#e8e2d7c7a8b76f6ee64c2181d6b8151441602d4e"
+  integrity sha512-mAk+hPSO8fLDkhV7V0dXazH5pDc6MrjBTPyD3VeKzxnVFjH1MIxbCdqGZB9O8+EwWakZs3ZCbDS4IpRt79V1ig==
 
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -2508,7 +2552,7 @@ has-flag@^4.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
-has-symbols@^1.0.0:
+has-symbols@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
   integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
@@ -2548,6 +2592,13 @@ has-values@^1.0.0:
   dependencies:
     is-number "^3.0.0"
     kind-of "^4.0.0"
+
+has@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
+  dependencies:
+    function-bind "^1.1.1"
 
 hash-base@^3.0.0:
   version "3.1.0"
@@ -2736,6 +2787,11 @@ is-buffer@^1.1.5:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
+is-callable@^1.1.4, is-callable@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.1.tgz#4d1e21a4f437509d25ce55f8184350771421c96d"
+  integrity sha512-wliAfSzx6V+6WfMOmus1xy0XvSgf/dlStkvTfq7F0g4bOIW0PSUbnyse3NhDwdyYS1ozfUtAAySqTws3z9Eqgg==
+
 is-data-descriptor@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
@@ -2749,6 +2805,11 @@ is-data-descriptor@^1.0.0:
   integrity sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==
   dependencies:
     kind-of "^6.0.0"
+
+is-date-object@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.2.tgz#bda736f2cd8fd06d32844e7743bfa7494c3bfd7e"
+  integrity sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -2816,6 +2877,11 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
+is-negative-zero@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.0.tgz#9553b121b0fac28869da9ed459e20c7543788461"
+  integrity sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=
+
 is-number@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
@@ -2834,6 +2900,20 @@ is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
   dependencies:
     isobject "^3.0.1"
+
+is-regex@^1.1.0, is-regex@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.1.tgz#c6f98aacc546f6cec5468a07b7b153ab564a57b9"
+  integrity sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==
+  dependencies:
+    has-symbols "^1.0.1"
+
+is-symbol@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.3.tgz#38e1014b9e6329be0de9d24a414fd7441ec61937"
+  integrity sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==
+  dependencies:
+    has-symbols "^1.0.1"
 
 is-typedarray@~1.0.0:
   version "1.0.0"
@@ -3409,7 +3489,7 @@ node-modules-regexp@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
-node-releases@^1.1.60:
+node-releases@^1.1.61:
   version "1.1.61"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.61.tgz#707b0fca9ce4e11783612ba4a2fcba09047af16e"
   integrity sha512-DD5vebQLg8jLCOzwupn954fbIiZht05DAZs0k2u8NStSe6h9XdsuIQL8hSRKYiU8WUQRznmSDrKGbv3ObOmC7g==
@@ -3500,7 +3580,12 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-keys@^1.0.11, object-keys@^1.0.12:
+object-inspect@^1.7.0, object-inspect@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.8.0.tgz#df807e5ecf53a609cc6bfe93eac3cc7be5b3a9d0"
+  integrity sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==
+
+object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
@@ -3513,14 +3598,14 @@ object-visit@^1.0.0:
     isobject "^3.0.0"
 
 object.assign@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
-  integrity sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.1.tgz#303867a666cdd41936ecdedfb1f8f3e32a478cdd"
+  integrity sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==
   dependencies:
-    define-properties "^1.1.2"
-    function-bind "^1.1.1"
-    has-symbols "^1.0.0"
-    object-keys "^1.0.11"
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.0"
+    has-symbols "^1.0.1"
+    object-keys "^1.1.1"
 
 object.pick@^1.3.0:
   version "1.3.0"
@@ -4273,6 +4358,13 @@ serialize-javascript@^4.0.0:
   dependencies:
     randombytes "^2.1.0"
 
+serialize-javascript@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-5.0.1.tgz#7886ec848049a462467a97d3d918ebb2aaf934f4"
+  integrity sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==
+  dependencies:
+    randombytes "^2.1.0"
+
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
@@ -4536,6 +4628,22 @@ string-width@^3.0.0, string-width@^3.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
+string.prototype.trimend@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz#85812a6b847ac002270f5808146064c995fb6913"
+  integrity sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.5"
+
+string.prototype.trimstart@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz#14af6d9f34b053f7cfc89b72f8f2ee14b9039a54"
+  integrity sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.5"
+
 string_decoder@^1.0.0, string_decoder@^1.1.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
@@ -4660,19 +4768,19 @@ terser-webpack-plugin@^1.4.3:
     webpack-sources "^1.4.0"
     worker-farm "^1.7.0"
 
-terser-webpack-plugin@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-4.1.0.tgz#6e9d6ae4e1a900d88ddce8da6a47507ea61f44bc"
-  integrity sha512-0ZWDPIP8BtEDZdChbufcXUigOYk6dOX/P/X0hWxqDDcVAQLb8Yy/0FAaemSfax3PAA67+DJR778oz8qVbmy4hA==
+terser-webpack-plugin@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-4.2.1.tgz#44b88ef4d7443129fb136a68b5ec3e80d63ec471"
+  integrity sha512-D0IZQNl1ZN/JivFNDFzOeU2Bk2LdQQESHJhKTHsodpUmISkaeRwVFk7gzHzX4OuQwanDGelOxIEsBt1SZ+s6nA==
   dependencies:
     cacache "^15.0.5"
     find-cache-dir "^3.3.1"
     jest-worker "^26.3.0"
     p-limit "^3.0.2"
-    schema-utils "^2.6.6"
-    serialize-javascript "^4.0.0"
+    schema-utils "^2.7.1"
+    serialize-javascript "^5.0.1"
     source-map "^0.6.1"
-    terser "^5.0.0"
+    terser "^5.3.1"
     webpack-sources "^1.4.3"
 
 terser@^4.1.2:
@@ -4684,10 +4792,10 @@ terser@^4.1.2:
     source-map "~0.6.1"
     source-map-support "~0.5.12"
 
-terser@^5.0.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.3.0.tgz#c481f4afecdcc182d5e2bdd2ff2dc61555161e81"
-  integrity sha512-XTT3D3AwxC54KywJijmY2mxZ8nJiEjBHVYzq8l9OaYuRFWeQNBwvipuzzYEP4e+/AVcd1hqG/CqgsdIRyT45Fg==
+terser@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.3.1.tgz#f50fe20ab48b15234fe9bdd86b10148ad5fca787"
+  integrity sha512-yD80f4hdwCWTH5mojzxe1q8bN1oJbsK/vfJGLcPZM/fl+/jItIVNKhFIHqqR71OipFWMLgj3Kc+GIp6CeIqfnA==
   dependencies:
     commander "^2.20.0"
     source-map "~0.6.1"


### PR DESCRIPTION
<!-- START pr-commits   please keep comment here to allow auto update -->
## Changes


* chore: update dependencies (28472f0b9fb7c03bf32ec29bc8f635987aacc482)

<!-- END pr-commits   please keep comment here to allow auto update -->

## Base PullRequest

default branch (https://github.com/wp-content-framework/travis-ci/tree/master)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/bin
```



</details>
<details>
<summary><em>composer bin:update</em></summary>

```Shell
yarn add v1.22.5
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@2.1.3: The platform "linux" is incompatible with this module.
info "fsevents@2.1.3" is an optional dependency and failed compatibility check. Excluding it from installation.
info fsevents@1.2.13: The platform "linux" is incompatible with this module.
info "fsevents@1.2.13" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved 50 new dependencies.
info Direct dependencies
├─ @wordpress/a11y@2.12.0
├─ @wordpress/annotations@1.21.0
├─ @wordpress/api-fetch@3.19.0
├─ @wordpress/autop@2.9.0
├─ @wordpress/babel-plugin-import-jsx-pragma@2.7.0
├─ @wordpress/blob@2.9.0
├─ @wordpress/block-directory@1.14.0
├─ @wordpress/block-editor@4.4.0
├─ @wordpress/block-library@2.23.0
├─ @wordpress/block-serialization-default-parser@3.7.0
├─ @wordpress/block-serialization-spec-parser@3.7.0
├─ @wordpress/blocks@6.21.0
├─ @wordpress/components@10.1.0
├─ @wordpress/compose@3.20.0
├─ @wordpress/core-data@2.21.0
├─ @wordpress/data-controls@1.17.0
├─ @wordpress/data@4.23.0
├─ @wordpress/date@3.11.0
├─ @wordpress/deprecated@2.9.0
├─ @wordpress/dom-ready@2.10.0
├─ @wordpress/dom@2.14.0
├─ @wordpress/edit-post@3.22.0
├─ @wordpress/edit-site@1.12.0
├─ @wordpress/editor@9.21.0
├─ @wordpress/element@2.17.0
├─ @wordpress/escape-html@1.9.0
├─ @wordpress/format-library@1.23.0
├─ @wordpress/hooks@2.9.0
├─ @wordpress/html-entities@2.8.0
├─ @wordpress/i18n@3.15.0
├─ @wordpress/icons@2.5.0
├─ @wordpress/is-shallow-equal@2.2.0
├─ @wordpress/keyboard-shortcuts@1.10.0
├─ @wordpress/keycodes@2.15.0
├─ @wordpress/list-reusable-blocks@1.22.0
├─ @wordpress/media-utils@1.16.0
├─ @wordpress/notices@2.9.0
├─ @wordpress/nux@3.21.0
├─ @wordpress/plugins@2.21.0
├─ @wordpress/primitives@1.8.0
├─ @wordpress/priority-queue@1.8.0
├─ @wordpress/redux-routine@3.11.0
├─ @wordpress/rich-text@3.21.0
├─ @wordpress/server-side-render@1.17.0
├─ @wordpress/shortcode@2.10.0
├─ @wordpress/token-list@1.12.0
├─ @wordpress/url@2.18.0
├─ @wordpress/viewport@2.22.0
├─ @wordpress/warning@1.3.0
└─ @wordpress/wordcount@2.11.0
info All dependencies
├─ @wordpress/a11y@2.12.0
├─ @wordpress/annotations@1.21.0
├─ @wordpress/api-fetch@3.19.0
├─ @wordpress/autop@2.9.0
├─ @wordpress/babel-plugin-import-jsx-pragma@2.7.0
├─ @wordpress/blob@2.9.0
├─ @wordpress/block-directory@1.14.0
├─ @wordpress/block-editor@4.4.0
├─ @wordpress/block-library@2.23.0
├─ @wordpress/block-serialization-default-parser@3.7.0
├─ @wordpress/block-serialization-spec-parser@3.7.0
├─ @wordpress/blocks@6.21.0
├─ @wordpress/components@10.1.0
├─ @wordpress/compose@3.20.0
├─ @wordpress/core-data@2.21.0
├─ @wordpress/data-controls@1.17.0
├─ @wordpress/data@4.23.0
├─ @wordpress/date@3.11.0
├─ @wordpress/deprecated@2.9.0
├─ @wordpress/dom-ready@2.10.0
├─ @wordpress/dom@2.14.0
├─ @wordpress/edit-post@3.22.0
├─ @wordpress/edit-site@1.12.0
├─ @wordpress/editor@9.21.0
├─ @wordpress/element@2.17.0
├─ @wordpress/escape-html@1.9.0
├─ @wordpress/format-library@1.23.0
├─ @wordpress/hooks@2.9.0
├─ @wordpress/html-entities@2.8.0
├─ @wordpress/i18n@3.15.0
├─ @wordpress/icons@2.5.0
├─ @wordpress/is-shallow-equal@2.2.0
├─ @wordpress/keyboard-shortcuts@1.10.0
├─ @wordpress/keycodes@2.15.0
├─ @wordpress/list-reusable-blocks@1.22.0
├─ @wordpress/media-utils@1.16.0
├─ @wordpress/notices@2.9.0
├─ @wordpress/nux@3.21.0
├─ @wordpress/plugins@2.21.0
├─ @wordpress/primitives@1.8.0
├─ @wordpress/priority-queue@1.8.0
├─ @wordpress/redux-routine@3.11.0
├─ @wordpress/rich-text@3.21.0
├─ @wordpress/server-side-render@1.17.0
├─ @wordpress/shortcode@2.10.0
├─ @wordpress/token-list@1.12.0
├─ @wordpress/url@2.18.0
├─ @wordpress/viewport@2.22.0
├─ @wordpress/warning@1.3.0
└─ @wordpress/wordcount@2.11.0
Done in 42.33s.

 terser-webpack-plugin  ^4.1.0  →  ^4.2.1   

Run npm install to install new versions.

yarn install v1.22.5
info No lockfile found.
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@2.1.3: The platform "linux" is incompatible with this module.
info "fsevents@2.1.3" is an optional dependency and failed compatibility check. Excluding it from installation.
info fsevents@1.2.13: The platform "linux" is incompatible with this module.
info "fsevents@1.2.13" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
Done in 12.74s.
yarn upgrade v1.22.5
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@2.1.3: The platform "linux" is incompatible with this module.
info "fsevents@2.1.3" is an optional dependency and failed compatibility check. Excluding it from installation.
info fsevents@1.2.13: The platform "linux" is incompatible with this module.
info "fsevents@1.2.13" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Rebuilding all packages...
success Saved lockfile.
success Saved 563 new dependencies.
info Direct dependencies
├─ @babel/core@7.11.6
├─ @babel/plugin-transform-react-jsx@7.10.4
├─ @babel/plugin-transform-runtime@7.11.5
├─ @babel/preset-env@7.11.5
├─ @babel/register@7.11.5
├─ @wordpress/annotations@1.21.0
├─ @wordpress/babel-plugin-import-jsx-pragma@2.7.0
├─ @wordpress/block-directory@1.14.0
├─ @wordpress/block-serialization-spec-parser@3.7.0
├─ @wordpress/edit-site@1.12.0
├─ @wordpress/format-library@1.23.0
├─ @wordpress/list-reusable-blocks@1.22.0
├─ @wordpress/nux@3.21.0
├─ babel-loader@8.1.0
├─ css-loader@4.3.0
├─ lodash@4.17.20
├─ node-sass@4.14.1
├─ sass-loader@10.0.2
├─ speed-measure-webpack-plugin@1.3.3
├─ style-loader@1.2.1
├─ terser-webpack-plugin@4.2.1
├─ webpack-cli@3.3.12
└─ webpack@4.44.1
info All dependencies
├─ @babel/code-frame@7.10.4
├─ @babel/compat-data@7.11.0
├─ @babel/core@7.11.6
├─ @babel/generator@7.11.6
├─ @babel/helper-builder-binary-assignment-operator-visitor@7.10.4
├─ @babel/helper-builder-react-jsx-experimental@7.11.5
├─ @babel/helper-builder-react-jsx@7.10.4
├─ @babel/helper-compilation-targets@7.10.4
├─ @babel/helper-define-map@7.10.5
├─ @babel/helper-explode-assignable-expression@7.11.4
├─ @babel/helper-hoist-variables@7.10.4
├─ @babel/helper-member-expression-to-functions@7.11.0
├─ @babel/helper-module-imports@7.10.4
├─ @babel/helper-wrap-function@7.10.4
├─ @babel/helpers@7.10.4
├─ @babel/highlight@7.10.4
├─ @babel/plugin-proposal-async-generator-functions@7.10.5
├─ @babel/plugin-proposal-class-properties@7.10.4
├─ @babel/plugin-proposal-dynamic-import@7.10.4
├─ @babel/plugin-proposal-export-namespace-from@7.10.4
├─ @babel/plugin-proposal-json-strings@7.10.4
├─ @babel/plugin-proposal-logical-assignment-operators@7.11.0
├─ @babel/plugin-proposal-nullish-coalescing-operator@7.10.4
├─ @babel/plugin-proposal-numeric-separator@7.10.4
├─ @babel/plugin-proposal-optional-catch-binding@7.10.4
├─ @babel/plugin-proposal-optional-chaining@7.11.0
├─ @babel/plugin-proposal-private-methods@7.10.4
├─ @babel/plugin-proposal-unicode-property-regex@7.10.4
├─ @babel/plugin-syntax-class-properties@7.10.4
├─ @babel/plugin-syntax-jsx@7.10.4
├─ @babel/plugin-syntax-top-level-await@7.10.4
├─ @babel/plugin-transform-arrow-functions@7.10.4
├─ @babel/plugin-transform-async-to-generator@7.10.4
├─ @babel/plugin-transform-block-scoped-functions@7.10.4
├─ @babel/plugin-transform-block-scoping@7.11.1
├─ @babel/plugin-transform-classes@7.10.4
├─ @babel/plugin-transform-computed-properties@7.10.4
├─ @babel/plugin-transform-destructuring@7.10.4
├─ @babel/plugin-transform-dotall-regex@7.10.4
├─ @babel/plugin-transform-duplicate-keys@7.10.4
├─ @babel/plugin-transform-exponentiation-operator@7.10.4
├─ @babel/plugin-transform-for-of@7.10.4
├─ @babel/plugin-transform-function-name@7.10.4
├─ @babel/plugin-transform-literals@7.10.4
├─ @babel/plugin-transform-member-expression-literals@7.10.4
├─ @babel/plugin-transform-modules-amd@7.10.5
├─ @babel/plugin-transform-modules-commonjs@7.10.4
├─ @babel/plugin-transform-modules-systemjs@7.10.5
├─ @babel/plugin-transform-modules-umd@7.10.4
├─ @babel/plugin-transform-named-capturing-groups-regex@7.10.4
├─ @babel/plugin-transform-new-target@7.10.4
├─ @babel/plugin-transform-object-super@7.10.4
├─ @babel/plugin-transform-property-literals@7.10.4
├─ @babel/plugin-transform-react-jsx@7.10.4
├─ @babel/plugin-transform-regenerator@7.10.4
├─ @babel/plugin-transform-reserved-words@7.10.4
├─ @babel/plugin-transform-runtime@7.11.5
├─ @babel/plugin-transform-shorthand-properties@7.10.4
├─ @babel/plugin-transform-spread@7.11.0
├─ @babel/plugin-transform-sticky-regex@7.10.4
├─ @babel/plugin-transform-template-literals@7.10.5
├─ @babel/plugin-transform-typeof-symbol@7.10.4
├─ @babel/plugin-transform-unicode-escapes@7.10.4
├─ @babel/plugin-transform-unicode-regex@7.10.4
├─ @babel/preset-env@7.11.5
├─ @babel/preset-modules@0.1.4
├─ @babel/register@7.11.5
├─ @emotion/cache@10.0.29
├─ @emotion/core@10.0.35
├─ @emotion/css@10.0.27
├─ @emotion/is-prop-valid@0.8.8
├─ @emotion/native@10.0.27
├─ @emotion/primitives-core@10.0.27
├─ @emotion/styled-base@10.0.31
├─ @emotion/styled@10.0.27
├─ @emotion/stylis@0.8.5
├─ @emotion/unitless@0.7.5
├─ @emotion/weak-memoize@0.2.5
├─ @npmcli/move-file@1.0.1
├─ @popperjs/core@2.4.4
├─ @tannin/compile@1.1.0
├─ @tannin/evaluate@1.2.0
├─ @tannin/plural-forms@1.1.0
├─ @tannin/postfix@1.1.0
├─ @types/json-schema@7.0.6
├─ @types/node@14.10.2
├─ @types/parse-json@4.0.0
├─ @webassemblyjs/floating-point-hex-parser@1.9.0
├─ @webassemblyjs/helper-code-frame@1.9.0
├─ @webassemblyjs/helper-fsm@1.9.0
├─ @webassemblyjs/helper-wasm-section@1.9.0
├─ @webassemblyjs/wasm-edit@1.9.0
├─ @webassemblyjs/wasm-opt@1.9.0
├─ @wordpress/annotations@1.21.0
├─ @wordpress/babel-plugin-import-jsx-pragma@2.7.0
├─ @wordpress/block-directory@1.14.0
├─ @wordpress/block-serialization-spec-parser@3.7.0
├─ @wordpress/edit-site@1.12.0
├─ @wordpress/format-library@1.23.0
├─ @wordpress/list-reusable-blocks@1.22.0
├─ @wordpress/nux@3.21.0
├─ @xtuc/ieee754@1.2.0
├─ abbrev@1.1.1
├─ acorn@6.4.1
├─ aggregate-error@3.1.0
├─ ajv-errors@1.0.1
├─ ajv-keywords@3.5.2
├─ ajv@6.12.5
├─ amdefine@1.0.1
├─ ansi-styles@3.2.1
├─ anymatch@3.1.1
├─ are-we-there-yet@1.1.5
├─ arr-flatten@1.1.0
├─ array-find-index@1.0.2
├─ array.prototype.find@2.1.1
├─ array.prototype.flat@1.2.3
├─ asap@2.0.6
├─ asn1.js@5.4.1
├─ asn1@0.2.4
├─ assert@1.5.0
├─ assign-symbols@1.0.0
├─ async-each@1.0.3
├─ async-foreach@0.1.3
├─ asynckit@0.4.0
├─ atob@2.1.2
├─ autosize@4.0.2
├─ aws-sign2@0.7.0
├─ aws4@1.10.1
├─ babel-loader@8.1.0
├─ babel-plugin-macros@2.8.0
├─ babel-plugin-syntax-jsx@6.18.0
├─ balanced-match@1.0.0
├─ base@0.11.2
├─ bcrypt-pbkdf@1.0.2
├─ binary-extensions@2.1.0
├─ block-stream@0.0.9
├─ bluebird@3.7.2
├─ body-scroll-lock@3.1.5
├─ brace-expansion@1.1.11
├─ braces@2.3.2
├─ brcast@2.0.2
├─ browserify-aes@1.2.0
├─ browserify-cipher@1.0.1
├─ browserify-des@1.0.2
├─ browserify-rsa@4.0.1
├─ browserify-sign@4.2.1
├─ browserify-zlib@0.2.0
├─ browserslist@4.14.2
├─ buffer-xor@1.0.3
├─ buffer@4.9.2
├─ builtin-status-codes@3.0.0
├─ cacache@15.0.5
├─ cache-base@1.0.1
├─ callsites@3.1.0
├─ camelcase-keys@2.1.0
├─ camelize@1.0.0
├─ caniuse-lite@1.0.30001131
├─ caseless@0.12.0
├─ chokidar@3.4.2
├─ chrome-trace-event@1.0.2
├─ class-utils@0.3.6
├─ clean-stack@2.2.0
├─ clipboard@2.0.6
├─ code-point-at@1.1.0
├─ collection-visit@1.0.0
├─ color-convert@1.9.3
├─ color-name@1.1.3
├─ combined-stream@1.0.8
├─ compute-scroll-into-view@1.0.16
├─ computed-style@0.1.4
├─ concat-map@0.0.1
├─ concat-stream@1.6.2
├─ console-browserify@1.2.0
├─ console-control-strings@1.1.0
├─ constants-browserify@1.0.0
├─ convert-source-map@1.7.0
├─ copy-concurrently@1.0.5
├─ copy-descriptor@0.1.1
├─ core-js-compat@3.6.5
├─ core-js@1.2.7
├─ core-util-is@1.0.2
├─ cosmiconfig@6.0.0
├─ create-ecdh@4.0.4
├─ create-hmac@1.1.7
├─ cross-spawn@3.0.1
├─ crypto-browserify@3.12.0
├─ css-color-keywords@1.0.0
├─ css-loader@4.3.0
├─ css-mediaquery@0.1.2
├─ css-to-react-native@2.3.2
├─ csstype@2.6.13
├─ currently-unhandled@0.4.1
├─ cyclist@1.0.1
├─ dashdash@1.14.1
├─ debug@2.6.9
├─ decode-uri-component@0.2.0
├─ deepmerge@1.5.2
├─ define-properties@1.1.3
├─ delayed-stream@1.0.0
├─ delegate@3.2.0
├─ des.js@1.0.1
├─ detect-file@1.0.0
├─ diff@4.0.2
├─ diffie-hellman@5.0.3
├─ direction@1.0.4
├─ document.contains@1.0.2
├─ dom-helpers@3.4.0
├─ domain-browser@1.2.0
├─ downloadjs@1.4.7
├─ downshift@5.4.7
├─ duplexify@3.7.1
├─ ecc-jsbn@0.1.2
├─ electron-to-chromium@1.3.568
├─ emoji-regex@7.0.3
├─ encoding@0.1.13
├─ enhanced-resolve@4.3.0
├─ errno@0.1.7
├─ error-ex@1.3.2
├─ escalade@3.1.0
├─ escape-string-regexp@1.0.5
├─ eslint-scope@4.0.3
├─ esrecurse@4.3.0
├─ estraverse@4.3.0
├─ esutils@2.0.3
├─ events@3.2.0
├─ evp_bytestokey@1.0.3
├─ expand-brackets@2.1.4
├─ expand-tilde@2.0.2
├─ extend@3.0.2
├─ extglob@2.0.4
├─ extsprintf@1.3.0
├─ fast-average-color@4.3.0
├─ fast-deep-equal@3.1.3
├─ fast-json-stable-stringify@2.1.0
├─ fast-memoize@2.5.2
├─ fbjs@0.8.17
├─ file-saver@2.0.2
├─ fill-range@4.0.0
├─ find-root@1.1.0
├─ findup-sync@3.0.0
├─ flush-write-stream@1.1.1
├─ for-in@1.0.2
├─ forever-agent@0.6.1
├─ form-data@2.3.3
├─ from2@2.3.0
├─ fs.realpath@1.0.0
├─ fstream@1.0.12
├─ function.prototype.name@1.1.2
├─ functions-have-names@1.2.1
├─ gauge@2.7.4
├─ gaze@1.1.3
├─ gensync@1.0.0-beta.1
├─ get-value@2.0.6
├─ getpass@0.1.7
├─ gettext-parser@1.4.0
├─ glob-parent@5.1.1
├─ global-cache@1.2.1
├─ global-modules@2.0.0
├─ global-prefix@3.0.0
├─ globule@1.3.2
├─ good-listener@1.2.2
├─ graceful-fs@4.2.4
├─ gradient-parser@0.1.5
├─ har-schema@2.0.0
├─ har-validator@5.1.5
├─ has-ansi@2.0.0
├─ has-unicode@2.0.1
├─ has-value@1.0.0
├─ hash.js@1.1.7
├─ hmac-drbg@1.0.1
├─ hoist-non-react-statics@3.3.2
├─ hosted-git-info@2.8.8
├─ hpq@1.3.0
├─ http-signature@1.2.0
├─ https-browserify@1.0.0
├─ iconv-lite@0.6.2
├─ icss-utils@4.1.1
├─ immediate@3.0.6
├─ import-fresh@3.2.1
├─ import-local@2.0.0
├─ in-publish@2.0.1
├─ indent-string@2.1.0
├─ indexes-of@1.0.1
├─ infer-owner@1.0.4
├─ inflight@1.0.6
├─ ini@1.3.5
├─ interpret@1.4.0
├─ is-accessor-descriptor@1.0.0
├─ is-arrayish@0.2.1
├─ is-binary-path@2.1.0
├─ is-data-descriptor@1.0.0
├─ is-date-object@1.0.2
├─ is-descriptor@1.0.2
├─ is-extglob@2.1.1
├─ is-finite@1.1.0
├─ is-glob@4.0.1
├─ is-negative-zero@2.0.0
├─ is-plain-object@2.0.4
├─ is-stream@1.1.0
├─ is-symbol@1.0.3
├─ is-touch-device@1.0.1
├─ is-typedarray@1.0.0
├─ is-utf8@0.2.1
├─ is-wsl@1.1.0
├─ isarray@1.0.0
├─ isexe@2.0.0
├─ isomorphic-fetch@2.2.1
├─ isstream@0.1.2
├─ jest-worker@26.3.0
├─ js-base64@2.6.4
├─ js-tokens@4.0.0
├─ jsesc@2.5.2
├─ json-parse-better-errors@1.0.2
├─ json-parse-even-better-errors@2.3.1
├─ json-schema-traverse@0.4.1
├─ json-schema@0.2.3
├─ json-stringify-safe@5.0.1
├─ jsprim@1.4.1
├─ jszip@3.5.0
├─ kind-of@3.2.2
├─ klona@2.0.3
├─ leven@3.1.0
├─ lie@3.3.0
├─ line-height@0.3.1
├─ lines-and-columns@1.1.6
├─ load-json-file@1.1.0
├─ loader-runner@2.4.0
├─ locate-path@3.0.0
├─ lodash@4.17.20
├─ loud-rejection@1.6.0
├─ lru-cache@4.1.5
├─ make-dir@2.1.0
├─ map-obj@1.0.1
├─ map-visit@1.0.0
├─ memory-fs@0.4.1
├─ meow@3.7.0
├─ merge-stream@2.0.0
├─ micromatch@3.1.10
├─ miller-rabin@4.0.1
├─ mime-db@1.44.0
├─ mime-types@2.1.27
├─ minimalistic-crypto-utils@1.0.1
├─ minimatch@3.0.4
├─ minimist@1.2.5
├─ minipass-collect@1.0.2
├─ minipass-flush@1.0.5
├─ minipass-pipeline@1.2.4
├─ minizlib@2.1.2
├─ mississippi@3.0.0
├─ mixin-deep@1.3.2
├─ moment-timezone@0.5.31
├─ moment@2.28.0
├─ mousetrap@1.6.5
├─ move-concurrently@1.0.1
├─ ms@2.0.0
├─ nan@2.14.1
├─ nanomatch@1.2.13
├─ neo-async@2.6.2
├─ nice-try@1.0.5
├─ node-fetch@1.7.3
├─ node-gyp@3.8.0
├─ node-libs-browser@2.2.1
├─ node-modules-regexp@1.0.0
├─ node-releases@1.1.61
├─ node-sass@4.14.1
├─ nopt@3.0.6
├─ normalize-package-data@2.5.0
├─ npmlog@4.1.2
├─ number-is-nan@1.0.1
├─ oauth-sign@0.9.0
├─ object-copy@0.1.0
├─ object-inspect@1.8.0
├─ object-is@1.1.2
├─ object.entries@1.1.2
├─ os-browserify@0.3.0
├─ os-homedir@1.0.2
├─ os-tmpdir@1.0.2
├─ osenv@0.1.5
├─ p-limit@2.3.0
├─ p-locate@3.0.0
├─ p-map@4.0.0
├─ pako@1.0.11
├─ parallel-transform@1.2.0
├─ parent-module@1.0.1
├─ parse-asn1@5.1.6
├─ parse-json@2.2.0
├─ parse-passwd@1.0.0
├─ pascalcase@0.1.1
├─ path-browserify@0.0.1
├─ path-dirname@1.0.2
├─ path-exists@3.0.0
├─ path-is-absolute@1.0.1
├─ path-key@2.0.1
├─ path-parse@1.0.6
├─ path-type@1.1.0
├─ pegjs@0.10.0
├─ performance-now@2.1.0
├─ phpegjs@1.0.0-beta7
├─ picomatch@2.2.2
├─ pinkie@2.0.4
├─ pirates@4.0.1
├─ posix-character-classes@0.1.1
├─ postcss-modules-extract-imports@2.0.0
├─ postcss-modules-local-by-default@3.0.3
├─ postcss-modules-scope@2.2.0
├─ postcss-modules-values@3.0.0
├─ postcss-selector-parser@6.0.2
├─ process-nextick-args@2.0.1
├─ process@0.11.10
├─ promise@7.3.1
├─ prop-types-exact@1.2.0
├─ prr@1.0.1
├─ pseudomap@1.0.2
├─ psl@1.8.0
├─ public-encrypt@4.0.3
├─ pump@3.0.0
├─ pumpify@1.5.1
├─ qs@6.9.4
├─ querystring-es3@0.2.1
├─ querystring@0.2.0
├─ randomfill@1.0.4
├─ re-resizable@6.5.5
├─ react-addons-shallow-compare@15.6.2
├─ react-dates@17.2.0
├─ react-dom@16.13.1
├─ react-easy-crop@3.1.1
├─ react-is@16.13.1
├─ react-lifecycles-compat@3.0.4
├─ react-merge-refs@1.1.0
├─ react-moment-proptypes@1.7.0
├─ react-native-url-polyfill@1.2.0
├─ react-outside-click-handler@1.3.0
├─ react-portal@4.2.1
├─ react-spring@8.0.27
├─ react-transition-group@2.9.0
├─ react-use-gesture@7.0.16
├─ react-with-direction@1.3.1
├─ react-with-styles-interface-css@4.0.3
├─ react-with-styles@3.2.3
├─ react@16.13.1
├─ read-pkg-up@1.0.1
├─ read-pkg@1.1.0
├─ readable-stream@2.3.7
├─ readdirp@3.4.0
├─ reakit-system@0.13.1
├─ reakit-warning@0.4.1
├─ reakit@1.1.0
├─ redent@1.0.0
├─ redux-multi@0.1.12
├─ redux-optimist@1.0.0
├─ redux@4.0.5
├─ reflect.ownkeys@0.2.0
├─ regenerate-unicode-properties@8.2.0
├─ regenerator-runtime@0.13.7
├─ regenerator-transform@0.14.5
├─ regexpu-core@4.7.0
├─ regjsgen@0.5.2
├─ regjsparser@0.6.4
├─ remove-trailing-separator@1.1.0
├─ repeat-element@1.1.3
├─ repeating@2.0.1
├─ request@2.88.2
├─ resolve-cwd@2.0.0
├─ resolve-dir@1.0.1
├─ resolve-from@3.0.0
├─ resolve-url@0.2.1
├─ resolve@1.17.0
├─ ret@0.1.15
├─ run-queue@1.0.3
├─ rungen@0.3.2
├─ sass-graph@2.2.5
├─ sass-loader@10.0.2
├─ scheduler@0.19.1
├─ scss-tokenizer@0.2.3
├─ select@1.1.2
├─ serialize-javascript@5.0.1
├─ set-immediate-shim@1.0.1
├─ set-value@2.0.1
├─ setimmediate@1.0.5
├─ shebang-command@1.2.0
├─ shebang-regex@1.0.0
├─ showdown@1.9.1
├─ simple-html-tokenizer@0.5.9
├─ snapdragon-node@2.1.1
├─ snapdragon-util@3.0.1
├─ source-list-map@2.0.1
├─ source-map-resolve@0.5.3
├─ source-map-url@0.4.0
├─ spdx-correct@3.1.1
├─ spdx-exceptions@2.3.0
├─ speed-measure-webpack-plugin@1.3.3
├─ split-string@3.1.0
├─ sprintf-js@1.1.2
├─ sshpk@1.16.1
├─ ssri@8.0.0
├─ static-extend@0.1.2
├─ stdout-stream@1.4.1
├─ stream-browserify@2.0.2
├─ stream-each@1.2.3
├─ stream-http@2.8.3
├─ string_decoder@1.3.0
├─ strip-bom@2.0.0
├─ strip-indent@1.0.1
├─ style-loader@1.2.1
├─ symbol-observable@1.2.0
├─ tannin@1.2.0
├─ tapable@1.1.3
├─ tar@2.2.2
├─ terser-webpack-plugin@4.2.1
├─ terser@5.3.1
├─ through2@2.0.5
├─ timers-browserify@2.0.11
├─ tiny-emitter@2.1.0
├─ to-arraybuffer@1.0.1
├─ to-fast-properties@2.0.0
├─ to-object-path@0.3.0
├─ to-regex-range@2.1.1
├─ tough-cookie@2.5.0
├─ traverse@0.6.6
├─ trim-newlines@1.0.0
├─ true-case-path@1.0.3
├─ tslib@1.11.2
├─ tty-browserify@0.0.0
├─ tunnel-agent@0.6.0
├─ turbo-combine-reducers@1.0.2
├─ tweetnacl@0.14.5
├─ typedarray@0.0.6
├─ ua-parser-js@0.7.22
├─ unicode-canonical-property-names-ecmascript@1.0.4
├─ unicode-match-property-ecmascript@1.0.4
├─ unicode-match-property-value-ecmascript@1.2.0
├─ unicode-property-aliases-ecmascript@1.1.0
├─ union-value@1.0.1
├─ uniq@1.0.1
├─ unique-slug@2.0.2
├─ unset-value@1.0.0
├─ upath@1.2.0
├─ uri-js@4.4.0
├─ urix@0.1.0
├─ url@0.11.0
├─ use-memo-one@1.1.1
├─ use@3.1.1
├─ util-deprecate@1.0.2
├─ util@0.11.1
├─ v8-compile-cache@2.1.1
├─ validate-npm-package-license@3.0.4
├─ verror@1.10.0
├─ vm-browserify@1.1.2
├─ watchpack-chokidar2@2.0.0
├─ watchpack@1.7.4
├─ webidl-conversions@5.0.0
├─ webpack-cli@3.3.12
├─ webpack-sources@1.4.3
├─ webpack@4.44.1
├─ whatwg-fetch@3.4.1
├─ whatwg-url-without-unicode@8.0.0-3
├─ which@1.3.1
├─ wide-align@1.1.3
├─ worker-farm@1.7.0
├─ wrap-ansi@5.1.0
├─ xtend@4.0.2
├─ yaml@1.10.0
└─ yargs-parser@13.1.2
Done in 9.56s.

 terser-webpack-plugin  ^4.1.0  →  ^4.2.1   

Run npm install to install new versions.

yarn install v1.22.5
info No lockfile found.
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@2.1.3: The platform "linux" is incompatible with this module.
info "fsevents@2.1.3" is an optional dependency and failed compatibility check. Excluding it from installation.
info fsevents@1.2.13: The platform "linux" is incompatible with this module.
info "fsevents@1.2.13" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
Done in 7.02s.
yarn upgrade v1.22.5
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@2.1.3: The platform "linux" is incompatible with this module.
info "fsevents@2.1.3" is an optional dependency and failed compatibility check. Excluding it from installation.
info fsevents@1.2.13: The platform "linux" is incompatible with this module.
info "fsevents@1.2.13" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Rebuilding all packages...
success Saved lockfile.
success Saved 444 new dependencies.
info Direct dependencies
├─ @babel/core@7.11.6
├─ @babel/plugin-transform-react-jsx@7.10.4
├─ @babel/plugin-transform-runtime@7.11.5
├─ @babel/preset-env@7.11.5
├─ @babel/register@7.11.5
├─ babel-loader@8.1.0
├─ css-loader@4.3.0
├─ node-sass@4.14.1
├─ sass-loader@10.0.2
├─ speed-measure-webpack-plugin@1.3.3
├─ style-loader@1.2.1
├─ terser-webpack-plugin@4.2.1
├─ webpack-cli@3.3.12
└─ webpack@4.44.1
info All dependencies
├─ @babel/compat-data@7.11.0
├─ @babel/core@7.11.6
├─ @babel/generator@7.11.6
├─ @babel/helper-builder-binary-assignment-operator-visitor@7.10.4
├─ @babel/helper-builder-react-jsx-experimental@7.11.5
├─ @babel/helper-builder-react-jsx@7.10.4
├─ @babel/helper-compilation-targets@7.10.4
├─ @babel/helper-define-map@7.10.5
├─ @babel/helper-explode-assignable-expression@7.11.4
├─ @babel/helper-hoist-variables@7.10.4
├─ @babel/helper-member-expression-to-functions@7.11.0
├─ @babel/helper-wrap-function@7.10.4
├─ @babel/helpers@7.10.4
├─ @babel/highlight@7.10.4
├─ @babel/plugin-proposal-async-generator-functions@7.10.5
├─ @babel/plugin-proposal-class-properties@7.10.4
├─ @babel/plugin-proposal-dynamic-import@7.10.4
├─ @babel/plugin-proposal-export-namespace-from@7.10.4
├─ @babel/plugin-proposal-json-strings@7.10.4
├─ @babel/plugin-proposal-logical-assignment-operators@7.11.0
├─ @babel/plugin-proposal-nullish-coalescing-operator@7.10.4
├─ @babel/plugin-proposal-numeric-separator@7.10.4
├─ @babel/plugin-proposal-optional-catch-binding@7.10.4
├─ @babel/plugin-proposal-optional-chaining@7.11.0
├─ @babel/plugin-proposal-private-methods@7.10.4
├─ @babel/plugin-proposal-unicode-property-regex@7.10.4
├─ @babel/plugin-syntax-class-properties@7.10.4
├─ @babel/plugin-syntax-jsx@7.10.4
├─ @babel/plugin-syntax-top-level-await@7.10.4
├─ @babel/plugin-transform-arrow-functions@7.10.4
├─ @babel/plugin-transform-async-to-generator@7.10.4
├─ @babel/plugin-transform-block-scoped-functions@7.10.4
├─ @babel/plugin-transform-block-scoping@7.11.1
├─ @babel/plugin-transform-classes@7.10.4
├─ @babel/plugin-transform-computed-properties@7.10.4
├─ @babel/plugin-transform-destructuring@7.10.4
├─ @babel/plugin-transform-dotall-regex@7.10.4
├─ @babel/plugin-transform-duplicate-keys@7.10.4
├─ @babel/plugin-transform-exponentiation-operator@7.10.4
├─ @babel/plugin-transform-for-of@7.10.4
├─ @babel/plugin-transform-function-name@7.10.4
├─ @babel/plugin-transform-literals@7.10.4
├─ @babel/plugin-transform-member-expression-literals@7.10.4
├─ @babel/plugin-transform-modules-amd@7.10.5
├─ @babel/plugin-transform-modules-commonjs@7.10.4
├─ @babel/plugin-transform-modules-systemjs@7.10.5
├─ @babel/plugin-transform-modules-umd@7.10.4
├─ @babel/plugin-transform-named-capturing-groups-regex@7.10.4
├─ @babel/plugin-transform-new-target@7.10.4
├─ @babel/plugin-transform-object-super@7.10.4
├─ @babel/plugin-transform-property-literals@7.10.4
├─ @babel/plugin-transform-react-jsx@7.10.4
├─ @babel/plugin-transform-regenerator@7.10.4
├─ @babel/plugin-transform-reserved-words@7.10.4
├─ @babel/plugin-transform-runtime@7.11.5
├─ @babel/plugin-transform-shorthand-properties@7.10.4
├─ @babel/plugin-transform-spread@7.11.0
├─ @babel/plugin-transform-sticky-regex@7.10.4
├─ @babel/plugin-transform-template-literals@7.10.5
├─ @babel/plugin-transform-typeof-symbol@7.10.4
├─ @babel/plugin-transform-unicode-escapes@7.10.4
├─ @babel/plugin-transform-unicode-regex@7.10.4
├─ @babel/preset-env@7.11.5
├─ @babel/preset-modules@0.1.4
├─ @babel/register@7.11.5
├─ @babel/runtime@7.11.2
├─ @npmcli/move-file@1.0.1
├─ @types/json-schema@7.0.6
├─ @types/node@14.10.2
├─ @webassemblyjs/floating-point-hex-parser@1.9.0
├─ @webassemblyjs/helper-code-frame@1.9.0
├─ @webassemblyjs/helper-fsm@1.9.0
├─ @webassemblyjs/helper-wasm-section@1.9.0
├─ @webassemblyjs/wasm-edit@1.9.0
├─ @webassemblyjs/wasm-opt@1.9.0
├─ @xtuc/ieee754@1.2.0
├─ abbrev@1.1.1
├─ acorn@6.4.1
├─ aggregate-error@3.1.0
├─ ajv-errors@1.0.1
├─ ajv-keywords@3.5.2
├─ ajv@6.12.5
├─ amdefine@1.0.1
├─ ansi-styles@3.2.1
├─ anymatch@3.1.1
├─ are-we-there-yet@1.1.5
├─ arr-flatten@1.1.0
├─ array-find-index@1.0.2
├─ asn1.js@5.4.1
├─ asn1@0.2.4
├─ assert@1.5.0
├─ assign-symbols@1.0.0
├─ async-each@1.0.3
├─ async-foreach@0.1.3
├─ asynckit@0.4.0
├─ atob@2.1.2
├─ aws-sign2@0.7.0
├─ aws4@1.10.1
├─ babel-loader@8.1.0
├─ balanced-match@1.0.0
├─ base@0.11.2
├─ base64-js@1.3.1
├─ bcrypt-pbkdf@1.0.2
├─ binary-extensions@2.1.0
├─ block-stream@0.0.9
├─ bluebird@3.7.2
├─ brace-expansion@1.1.11
├─ braces@2.3.2
├─ browserify-aes@1.2.0
├─ browserify-cipher@1.0.1
├─ browserify-des@1.0.2
├─ browserify-rsa@4.0.1
├─ browserify-sign@4.2.1
├─ browserify-zlib@0.2.0
├─ browserslist@4.14.2
├─ buffer-xor@1.0.3
├─ buffer@4.9.2
├─ builtin-status-codes@3.0.0
├─ cacache@15.0.5
├─ cache-base@1.0.1
├─ camelcase-keys@2.1.0
├─ camelcase@6.0.0
├─ caniuse-lite@1.0.30001131
├─ caseless@0.12.0
├─ chokidar@3.4.2
├─ chrome-trace-event@1.0.2
├─ class-utils@0.3.6
├─ clean-stack@2.2.0
├─ cliui@5.0.0
├─ code-point-at@1.1.0
├─ collection-visit@1.0.0
├─ color-convert@1.9.3
├─ color-name@1.1.3
├─ combined-stream@1.0.8
├─ concat-map@0.0.1
├─ concat-stream@1.6.2
├─ console-browserify@1.2.0
├─ console-control-strings@1.1.0
├─ constants-browserify@1.0.0
├─ convert-source-map@1.7.0
├─ copy-concurrently@1.0.5
├─ copy-descriptor@0.1.1
├─ core-js-compat@3.6.5
├─ core-util-is@1.0.2
├─ create-ecdh@4.0.4
├─ create-hmac@1.1.7
├─ cross-spawn@3.0.1
├─ crypto-browserify@3.12.0
├─ css-loader@4.3.0
├─ currently-unhandled@0.4.1
├─ cyclist@1.0.1
├─ dashdash@1.14.1
├─ debug@2.6.9
├─ decamelize@1.2.0
├─ decode-uri-component@0.2.0
├─ delayed-stream@1.0.0
├─ delegates@1.0.0
├─ des.js@1.0.1
├─ detect-file@1.0.0
├─ diffie-hellman@5.0.3
├─ domain-browser@1.2.0
├─ duplexify@3.7.1
├─ ecc-jsbn@0.1.2
├─ electron-to-chromium@1.3.568
├─ emoji-regex@7.0.3
├─ enhanced-resolve@4.3.0
├─ errno@0.1.7
├─ error-ex@1.3.2
├─ es-abstract@1.18.0-next.0
├─ escalade@3.1.0
├─ escape-string-regexp@1.0.5
├─ eslint-scope@4.0.3
├─ esrecurse@4.3.0
├─ estraverse@4.3.0
├─ esutils@2.0.3
├─ events@3.2.0
├─ evp_bytestokey@1.0.3
├─ expand-brackets@2.1.4
├─ expand-tilde@2.0.2
├─ extend@3.0.2
├─ extglob@2.0.4
├─ extsprintf@1.3.0
├─ fast-deep-equal@3.1.3
├─ fast-json-stable-stringify@2.1.0
├─ fill-range@4.0.0
├─ findup-sync@3.0.0
├─ flush-write-stream@1.1.1
├─ for-in@1.0.2
├─ forever-agent@0.6.1
├─ form-data@2.3.3
├─ from2@2.3.0
├─ fs.realpath@1.0.0
├─ fstream@1.0.12
├─ gauge@2.7.4
├─ gaze@1.1.3
├─ gensync@1.0.0-beta.1
├─ get-caller-file@2.0.5
├─ getpass@0.1.7
├─ glob-parent@5.1.1
├─ global-modules@2.0.0
├─ global-prefix@3.0.0
├─ globule@1.3.2
├─ graceful-fs@4.2.4
├─ har-schema@2.0.0
├─ har-validator@5.1.5
├─ has-ansi@2.0.0
├─ has-unicode@2.0.1
├─ has-value@1.0.0
├─ hash.js@1.1.7
├─ hmac-drbg@1.0.1
├─ hosted-git-info@2.8.8
├─ http-signature@1.2.0
├─ https-browserify@1.0.0
├─ ieee754@1.1.13
├─ import-local@2.0.0
├─ in-publish@2.0.1
├─ indent-string@2.1.0
├─ indexes-of@1.0.1
├─ infer-owner@1.0.4
├─ inflight@1.0.6
├─ ini@1.3.5
├─ interpret@1.4.0
├─ is-accessor-descriptor@1.0.0
├─ is-arrayish@0.2.1
├─ is-binary-path@2.1.0
├─ is-data-descriptor@1.0.0
├─ is-date-object@1.0.2
├─ is-descriptor@1.0.2
├─ is-extglob@2.1.1
├─ is-finite@1.1.0
├─ is-glob@4.0.1
├─ is-negative-zero@2.0.0
├─ is-plain-object@2.0.4
├─ is-regex@1.1.1
├─ is-symbol@1.0.3
├─ is-typedarray@1.0.0
├─ is-utf8@0.2.1
├─ is-wsl@1.1.0
├─ isarray@1.0.0
├─ isexe@2.0.0
├─ isstream@0.1.2
├─ jest-worker@26.3.0
├─ js-base64@2.6.4
├─ js-tokens@4.0.0
├─ jsesc@2.5.2
├─ json-parse-better-errors@1.0.2
├─ json-schema-traverse@0.4.1
├─ json-schema@0.2.3
├─ json-stringify-safe@5.0.1
├─ jsprim@1.4.1
├─ kind-of@3.2.2
├─ klona@2.0.3
├─ leven@3.1.0
├─ load-json-file@1.1.0
├─ loader-runner@2.4.0
├─ locate-path@3.0.0
├─ lodash@4.17.20
├─ loose-envify@1.4.0
├─ loud-rejection@1.6.0
├─ lru-cache@4.1.5
├─ make-dir@2.1.0
├─ map-obj@1.0.1
├─ map-visit@1.0.0
├─ memory-fs@0.4.1
├─ meow@3.7.0
├─ merge-stream@2.0.0
├─ micromatch@3.1.10
├─ miller-rabin@4.0.1
├─ mime-db@1.44.0
├─ mime-types@2.1.27
├─ minimalistic-crypto-utils@1.0.1
├─ minimatch@3.0.4
├─ minimist@1.2.5
├─ minipass-collect@1.0.2
├─ minipass-flush@1.0.5
├─ minipass-pipeline@1.2.4
├─ minizlib@2.1.2
├─ mississippi@3.0.0
├─ mixin-deep@1.3.2
├─ move-concurrently@1.0.1
├─ ms@2.0.0
├─ nan@2.14.1
├─ nanomatch@1.2.13
├─ neo-async@2.6.2
├─ nice-try@1.0.5
├─ node-gyp@3.8.0
├─ node-libs-browser@2.2.1
├─ node-modules-regexp@1.0.0
├─ node-releases@1.1.61
├─ node-sass@4.14.1
├─ nopt@3.0.6
├─ normalize-package-data@2.5.0
├─ npmlog@4.1.2
├─ number-is-nan@1.0.1
├─ oauth-sign@0.9.0
├─ object-assign@4.1.1
├─ object-copy@0.1.0
├─ object-inspect@1.8.0
├─ os-browserify@0.3.0
├─ os-homedir@1.0.2
├─ os-tmpdir@1.0.2
├─ osenv@0.1.5
├─ p-limit@2.3.0
├─ p-locate@3.0.0
├─ p-map@4.0.0
├─ pako@1.0.11
├─ parallel-transform@1.2.0
├─ parse-asn1@5.1.6
├─ parse-json@2.2.0
├─ parse-passwd@1.0.0
├─ pascalcase@0.1.1
├─ path-browserify@0.0.1
├─ path-dirname@1.0.2
├─ path-exists@3.0.0
├─ path-is-absolute@1.0.1
├─ path-key@2.0.1
├─ path-parse@1.0.6
├─ path-type@1.1.0
├─ performance-now@2.1.0
├─ picomatch@2.2.2
├─ pinkie@2.0.4
├─ pirates@4.0.1
├─ posix-character-classes@0.1.1
├─ postcss-modules-extract-imports@2.0.0
├─ postcss-modules-local-by-default@3.0.3
├─ postcss-modules-scope@2.2.0
├─ postcss-modules-values@3.0.0
├─ postcss-selector-parser@6.0.2
├─ process-nextick-args@2.0.1
├─ process@0.11.10
├─ prr@1.0.1
├─ pseudomap@1.0.2
├─ psl@1.8.0
├─ public-encrypt@4.0.3
├─ pump@3.0.0
├─ pumpify@1.5.1
├─ punycode@2.1.1
├─ qs@6.5.2
├─ querystring-es3@0.2.1
├─ querystring@0.2.0
├─ randomfill@1.0.4
├─ read-pkg-up@1.0.1
├─ read-pkg@1.1.0
├─ readable-stream@2.3.7
├─ readdirp@3.4.0
├─ redent@1.0.0
├─ regenerate-unicode-properties@8.2.0
├─ regenerator-runtime@0.13.7
├─ regenerator-transform@0.14.5
├─ regexpu-core@4.7.0
├─ regjsgen@0.5.2
├─ regjsparser@0.6.4
├─ remove-trailing-separator@1.1.0
├─ repeat-element@1.1.3
├─ repeating@2.0.1
├─ request@2.88.2
├─ require-directory@2.1.1
├─ require-main-filename@2.0.0
├─ resolve-cwd@2.0.0
├─ resolve-dir@1.0.1
├─ resolve-from@3.0.0
├─ resolve-url@0.2.1
├─ resolve@1.17.0
├─ ret@0.1.15
├─ run-queue@1.0.3
├─ sass-graph@2.2.5
├─ sass-loader@10.0.2
├─ scss-tokenizer@0.2.3
├─ serialize-javascript@5.0.1
├─ set-blocking@2.0.0
├─ set-value@2.0.1
├─ setimmediate@1.0.5
├─ shebang-command@1.2.0
├─ shebang-regex@1.0.0
├─ snapdragon-node@2.1.1
├─ snapdragon-util@3.0.1
├─ source-list-map@2.0.1
├─ source-map-resolve@0.5.3
├─ source-map-url@0.4.0
├─ spdx-correct@3.1.1
├─ spdx-exceptions@2.3.0
├─ speed-measure-webpack-plugin@1.3.3
├─ split-string@3.1.0
├─ sshpk@1.16.1
├─ ssri@8.0.0
├─ static-extend@0.1.2
├─ stdout-stream@1.4.1
├─ stream-browserify@2.0.2
├─ stream-each@1.2.3
├─ stream-http@2.8.3
├─ string_decoder@1.3.0
├─ strip-bom@2.0.0
├─ strip-indent@1.0.1
├─ style-loader@1.2.1
├─ tapable@1.1.3
├─ tar@2.2.2
├─ terser-webpack-plugin@4.2.1
├─ terser@5.3.1
├─ through2@2.0.5
├─ timers-browserify@2.0.11
├─ to-arraybuffer@1.0.1
├─ to-fast-properties@2.0.0
├─ to-object-path@0.3.0
├─ to-regex-range@2.1.1
├─ tough-cookie@2.5.0
├─ trim-newlines@1.0.0
├─ true-case-path@1.0.3
├─ tslib@1.13.0
├─ tty-browserify@0.0.0
├─ tunnel-agent@0.6.0
��─ tweetnacl@0.14.5
├─ typedarray@0.0.6
├─ unicode-canonical-property-names-ecmascript@1.0.4
├─ unicode-match-property-ecmascript@1.0.4
├─ unicode-match-property-value-ecmascript@1.2.0
├─ unicode-property-aliases-ecmascript@1.1.0
├─ union-value@1.0.1
├─ uniq@1.0.1
├─ unique-slug@2.0.2
├─ unset-value@1.0.0
├─ upath@1.2.0
├─ uri-js@4.4.0
├─ urix@0.1.0
├─ url@0.11.0
├─ use@3.1.1
├─ util-deprecate@1.0.2
├─ util@0.11.1
├─ uuid@3.4.0
├─ v8-compile-cache@2.1.1
├─ validate-npm-package-license@3.0.4
├─ verror@1.10.0
├─ vm-browserify@1.1.2
├─ watchpack-chokidar2@2.0.0
├─ watchpack@1.7.4
├─ webpack-cli@3.3.12
├─ webpack-sources@1.4.3
├─ webpack@4.44.1
├─ which-module@2.0.0
├─ which@1.3.1
├─ wide-align@1.1.3
├─ worker-farm@1.7.0
├─ wrap-ansi@5.1.0
├─ xtend@4.0.2
└─ yargs-parser@13.1.2
Done in 5.62s.
```

### stderr:

```Shell
> TRAVIS_BUILD_DIR=$(cd $(dirname $0); pwd) bash bin/self/package.sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0100   345  100   345    0     0   1380      0 --:--:-- --:--:-- --:--:--  1374
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0100  1241  100  1241    0     0   9261      0 --:--:-- --:--:-- --:--:--  9261
warning "@wordpress/data > use-memo-one@1.1.1" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/components > react-resize-aware@3.0.1" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/url > react-native-url-polyfill@1.2.0" has unmet peer dependency "react-native@*".
warning "@wordpress/block-editor > react-autosize-textarea@3.0.3" has unmet peer dependency "react@^0.14.0 || ^15.0.0 || ^16.0.0".
warning "@wordpress/block-editor > react-autosize-textarea@3.0.3" has unmet peer dependency "react-dom@^0.14.0 || ^15.0.0 || ^16.0.0".
warning "@wordpress/block-editor > react-spring@8.0.27" has unmet peer dependency "react@>= 16.8.0".
warning "@wordpress/block-editor > react-spring@8.0.27" has unmet peer dependency "react-dom@>= 16.8.0".
warning "@wordpress/block-editor > react-transition-group@2.9.0" has unmet peer dependency "react@>=15.0.0".
warning "@wordpress/block-editor > react-transition-group@2.9.0" has unmet peer dependency "react-dom@>=15.0.0".
warning "@wordpress/block-editor > reakit@1.1.0" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-editor > reakit@1.1.0" has unmet peer dependency "react-dom@^16.8.0".
warning "@wordpress/components > @emotion/core@10.0.35" has unmet peer dependency "react@>=16.3.0".
warning "@wordpress/components > @emotion/native@10.0.27" has unmet peer dependency "react-native@>=0.14.0 <1".
warning "@wordpress/components > @emotion/styled@10.0.27" has unmet peer dependency "react@>=16.3.0".
warning "@wordpress/components > downshift@5.4.7" has unmet peer dependency "react@>=16.8.0".
warning "@wordpress/components > react-dates@17.2.0" has unmet peer dependency "react@^0.14 || ^15.5.4 || ^16.1.1".
warning "@wordpress/components > react-dates@17.2.0" has unmet peer dependency "react-dom@^0.14 || ^15.5.4 || ^16.1.1".
warning "@wordpress/components > react-use-gesture@7.0.16" has unmet peer dependency "react@>= 16.8.0".
warning "@wordpress/components > reakit@1.2.4" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/components > reakit@1.2.4" has unmet peer dependency "react-dom@^16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > reakit > reakit-system@0.13.1" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > reakit > reakit-system@0.13.1" has unmet peer dependency "react-dom@^16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > reakit > reakit-utils@0.13.1" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > reakit > reakit-utils@0.13.1" has unmet peer dependency "react-dom@^16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > reakit > reakit-warning@0.4.1" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > @emotion/native > @emotion/primitives-core@10.0.27" has unmet peer dependency "react@>=16.3.0".
warning "@wordpress/block-directory > @wordpress/components > @emotion/styled > @emotion/styled-base@10.0.31" has unmet peer dependency "react@>=16.3.0".
warning "@wordpress/block-directory > @wordpress/components > react-dates > airbnb-prop-types@2.16.0" has unmet peer dependency "react@^0.14 || ^15.0.0 || ^16.0.0-alpha".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-outside-click-handler@1.3.0" has unmet peer dependency "react@^0.14 || >=15".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-outside-click-handler@1.3.0" has unmet peer dependency "react-dom@^0.14 || >=15".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-portal@4.2.1" has unmet peer dependency "react@^15.0.0-0 || ^16.0.0-0 || ^17.0.0-0".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-with-styles@3.2.3" has unmet peer dependency "react@>=0.14".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-with-styles@3.2.3" has unmet peer dependency "react-with-direction@^1.1.0".
warning "@wordpress/block-directory > @wordpress/components > reakit > reakit-system@0.14.4" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > reakit > reakit-system@0.14.4" has unmet peer dependency "react-dom@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > reakit > reakit-utils@0.14.3" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > reakit > reakit-utils@0.14.3" has unmet peer dependency "react-dom@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > reakit > reakit-warning@0.5.4" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-library > react-easy-crop@3.1.1" has unmet peer dependency "react@>=16.4.0".
warning "@wordpress/block-library > react-easy-crop@3.1.1" has unmet peer dependency "react-dom@>=16.4.0".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-with-styles > react-with-direction@1.3.1" has unmet peer dependency "react@^0.14 || ^15 || ^16".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-with-styles > react-with-direction@1.3.1" has unmet peer dependency "react-dom@^0.14 || ^15 || ^16".
npx: installed 303 in 18.764s

warning @wordpress/block-directory > @wordpress/components > react-dates > react-addons-shallow-compare > fbjs > core-js@1.2.7: core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.
warning node-sass > request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
warning node-sass > node-gyp > request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
warning node-sass > request > har-validator@5.1.5: this library is no longer supported
warning webpack > watchpack > watchpack-chokidar2 > chokidar@2.1.8: Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.
warning webpack > watchpack > watchpack-chokidar2 > chokidar > fsevents@1.2.13: fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.
warning webpack > micromatch > snapdragon > source-map-resolve > resolve-url@0.2.1: https://github.com/lydell/resolve-url#deprecated
warning webpack > micromatch > snapdragon > source-map-resolve > urix@0.1.0: Please see https://github.com/lydell/urix#deprecated
warning "@wordpress/annotations > @wordpress/data > use-memo-one@1.1.1" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > react-resize-aware@3.0.1" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/api-fetch > @wordpress/url > react-native-url-polyfill@1.2.0" has unmet peer dependency "react-native@*".
warning "@wordpress/block-directory > @wordpress/block-editor > react-transition-group@2.9.0" has unmet peer dependency "react@>=15.0.0".
warning "@wordpress/block-directory > @wordpress/block-editor > react-transition-group@2.9.0" has unmet peer dependency "react-dom@>=15.0.0".
warning "@wordpress/block-directory > @wordpress/block-editor > react-autosize-textarea@3.0.3" has unmet peer dependency "react@^0.14.0 || ^15.0.0 || ^16.0.0".
warning "@wordpress/block-directory > @wordpress/block-editor > react-autosize-textarea@3.0.3" has unmet peer dependency "react-dom@^0.14.0 || ^15.0.0 || ^16.0.0".
warning "@wordpress/block-directory > @wordpress/block-editor > react-spring@8.0.27" has unmet peer dependency "react@>= 16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > react-spring@8.0.27" has unmet peer dependency "react-dom@>= 16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > reakit@1.1.0" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > reakit@1.1.0" has unmet peer dependency "react-dom@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > reakit@1.2.4" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > reakit@1.2.4" has unmet peer dependency "react-dom@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > @emotion/native@10.0.27" has unmet peer dependency "react-native@>=0.14.0 <1".
warning "@wordpress/block-directory > @wordpress/components > @emotion/core@10.0.35" has unmet peer dependency "react@>=16.3.0".
warning "@wordpress/block-directory > @wordpress/components > downshift@5.4.7" has unmet peer dependency "react@>=16.8.0".
warning "@wordpress/block-directory > @wordpress/components > @emotion/styled@10.0.27" has unmet peer dependency "react@>=16.3.0".
warning "@wordpress/block-directory > @wordpress/components > react-dates@17.2.0" has unmet peer dependency "react@^0.14 || ^15.5.4 || ^16.1.1".
warning "@wordpress/block-directory > @wordpress/components > react-dates@17.2.0" has unmet peer dependency "react-dom@^0.14 || ^15.5.4 || ^16.1.1".
warning "@wordpress/block-directory > @wordpress/components > react-use-gesture@7.0.16" has unmet peer dependency "react@>= 16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > reakit > reakit-warning@0.4.1" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > reakit > reakit-warning@0.5.4" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > reakit > reakit-system@0.13.1" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > reakit > reakit-system@0.13.1" has unmet peer dependency "react-dom@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > reakit > reakit-system@0.14.4" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > reakit > reakit-system@0.14.4" has unmet peer dependency "react-dom@^16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > reakit > reakit-utils@0.13.1" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > reakit > reakit-utils@0.13.1" has unmet peer dependency "react-dom@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > reakit > reakit-utils@0.14.3" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > reakit > reakit-utils@0.14.3" has unmet peer dependency "react-dom@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > @emotion/native > @emotion/primitives-core@10.0.27" has unmet peer dependency "react@>=16.3.0".
warning "@wordpress/block-directory > @wordpress/components > react-dates > airbnb-prop-types@2.16.0" has unmet peer dependency "react@^0.14 || ^15.0.0 || ^16.0.0-alpha".
warning "@wordpress/block-directory > @wordpress/components > @emotion/styled > @emotion/styled-base@10.0.31" has unmet peer dependency "react@>=16.3.0".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-portal@4.2.1" has unmet peer dependency "react@^15.0.0-0 || ^16.0.0-0 || ^17.0.0-0".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-outside-click-handler@1.3.0" has unmet peer dependency "react@^0.14 || >=15".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-outside-click-handler@1.3.0" has unmet peer dependency "react-dom@^0.14 || >=15".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-with-styles@3.2.3" has unmet peer dependency "react@>=0.14".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-with-styles@3.2.3" has unmet peer dependency "react-with-direction@^1.1.0".
warning "@wordpress/block-directory > @wordpress/edit-post > @wordpress/block-library > react-easy-crop@3.1.1" has unmet peer dependency "react@>=16.4.0".
warning "@wordpress/block-directory > @wordpress/edit-post > @wordpress/block-library > react-easy-crop@3.1.1" has unmet peer dependency "react-dom@>=16.4.0".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-with-styles > react-with-direction@1.3.1" has unmet peer dependency "react@^0.14 || ^15 || ^16".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-with-styles > react-with-direction@1.3.1" has unmet peer dependency "react-dom@^0.14 || ^15 || ^16".
warning @wordpress/block-directory > @wordpress/components > react-dates > react-addons-shallow-compare > fbjs > core-js@1.2.7: core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.
warning node-sass > request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
warning node-sass > node-gyp > request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
warning node-sass > request > har-validator@5.1.5: this library is no longer supported
warning webpack > watchpack > watchpack-chokidar2 > chokidar@2.1.8: Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.
warning webpack > watchpack > watchpack-chokidar2 > chokidar > fsevents@1.2.13: fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.
warning webpack > micromatch > snapdragon > source-map-resolve > resolve-url@0.2.1: https://github.com/lydell/resolve-url#deprecated
warning webpack > micromatch > snapdragon > source-map-resolve > urix@0.1.0: Please see https://github.com/lydell/urix#deprecated
warning "@wordpress/annotations > @wordpress/data > use-memo-one@1.1.1" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > react-resize-aware@3.0.1" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/api-fetch > @wordpress/url > react-native-url-polyfill@1.2.0" has unmet peer dependency "react-native@*".
warning "@wordpress/block-directory > @wordpress/block-editor > react-transition-group@2.9.0" has unmet peer dependency "react@>=15.0.0".
warning "@wordpress/block-directory > @wordpress/block-editor > react-transition-group@2.9.0" has unmet peer dependency "react-dom@>=15.0.0".
warning "@wordpress/block-directory > @wordpress/block-editor > react-autosize-textarea@3.0.3" has unmet peer dependency "react@^0.14.0 || ^15.0.0 || ^16.0.0".
warning "@wordpress/block-directory > @wordpress/block-editor > react-autosize-textarea@3.0.3" has unmet peer dependency "react-dom@^0.14.0 || ^15.0.0 || ^16.0.0".
warning "@wordpress/block-directory > @wordpress/block-editor > reakit@1.1.0" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > reakit@1.1.0" has unmet peer dependency "react-dom@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > reakit@1.2.4" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > reakit@1.2.4" has unmet peer dependency "react-dom@^16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > react-spring@8.0.27" has unmet peer dependency "react@>= 16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > react-spring@8.0.27" has unmet peer dependency "react-dom@>= 16.8.0".
warning "@wordpress/block-directory > @wordpress/components > @emotion/core@10.0.35" has unmet peer dependency "react@>=16.3.0".
warning "@wordpress/block-directory > @wordpress/components > downshift@5.4.7" has unmet peer dependency "react@>=16.8.0".
warning "@wordpress/block-directory > @wordpress/components > @emotion/native@10.0.27" has unmet peer dependency "react-native@>=0.14.0 <1".
warning "@wordpress/block-directory > @wordpress/components > @emotion/styled@10.0.27" has unmet peer dependency "react@>=16.3.0".
warning "@wordpress/block-directory > @wordpress/components > react-dates@17.2.0" has unmet peer dependency "react@^0.14 || ^15.5.4 || ^16.1.1".
warning "@wordpress/block-directory > @wordpress/components > react-dates@17.2.0" has unmet peer dependency "react-dom@^0.14 || ^15.5.4 || ^16.1.1".
warning "@wordpress/block-directory > @wordpress/components > react-use-gesture@7.0.16" has unmet peer dependency "react@>= 16.8.0".
warning "@wordpress/block-directory > @wordpress/edit-post > @wordpress/block-library > react-easy-crop@3.1.1" has unmet peer dependency "react@>=16.4.0".
warning "@wordpress/block-directory > @wordpress/edit-post > @wordpress/block-library > react-easy-crop@3.1.1" has unmet peer dependency "react-dom@>=16.4.0".
warning "@wordpress/block-directory > @wordpress/block-editor > reakit > reakit-system@0.13.1" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > reakit > reakit-system@0.13.1" has unmet peer dependency "react-dom@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > reakit > reakit-system@0.14.4" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > reakit > reakit-system@0.14.4" has unmet peer dependency "react-dom@^16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > reakit > reakit-warning@0.4.1" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > reakit > reakit-warning@0.5.4" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > reakit > reakit-utils@0.13.1" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/block-editor > reakit > reakit-utils@0.13.1" has unmet peer dependency "react-dom@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > reakit > reakit-utils@0.14.3" has unmet peer dependency "react@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > reakit > reakit-utils@0.14.3" has unmet peer dependency "react-dom@^16.8.0".
warning "@wordpress/block-directory > @wordpress/components > react-dates > airbnb-prop-types@2.16.0" has unmet peer dependency "react@^0.14 || ^15.0.0 || ^16.0.0-alpha".
warning "@wordpress/block-directory > @wordpress/components > @emotion/styled > @emotion/styled-base@10.0.31" has unmet peer dependency "react@>=16.3.0".
warning "@wordpress/block-directory > @wordpress/components > @emotion/native > @emotion/primitives-core@10.0.27" has unmet peer dependency "react@>=16.3.0".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-portal@4.2.1" has unmet peer dependency "react@^15.0.0-0 || ^16.0.0-0 || ^17.0.0-0".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-with-styles@3.2.3" has unmet peer dependency "react@>=0.14".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-with-styles@3.2.3" has unmet peer dependency "react-with-direction@^1.1.0".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-outside-click-handler@1.3.0" has unmet peer dependency "react@^0.14 || >=15".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-outside-click-handler@1.3.0" has unmet peer dependency "react-dom@^0.14 || >=15".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-with-styles > react-with-direction@1.3.1" has unmet peer dependency "react@^0.14 || ^15 || ^16".
warning "@wordpress/block-directory > @wordpress/components > react-dates > react-with-styles > react-with-direction@1.3.1" has unmet peer dependency "react-dom@^0.14 || ^15 || ^16".
npx: installed 303 in 7.814s

warning node-sass > request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
warning node-sass > node-gyp > request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
warning node-sass > request > har-validator@5.1.5: this library is no longer supported
warning webpack > watchpack > watchpack-chokidar2 > chokidar@2.1.8: Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.
warning webpack > watchpack > watchpack-chokidar2 > chokidar > fsevents@1.2.13: fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.
warning webpack > micromatch > snapdragon > source-map-resolve > resolve-url@0.2.1: https://github.com/lydell/resolve-url#deprecated
warning webpack > micromatch > snapdragon > source-map-resolve > urix@0.1.0: Please see https://github.com/lydell/urix#deprecated
warning node-sass > request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
warning node-sass > node-gyp > request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
warning node-sass > request > har-validator@5.1.5: this library is no longer supported
warning webpack > watchpack > watchpack-chokidar2 > chokidar@2.1.8: Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.
warning webpack > watchpack > watchpack-chokidar2 > chokidar > fsevents@1.2.13: fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.
warning webpack > micromatch > snapdragon > source-map-resolve > resolve-url@0.2.1: https://github.com/lydell/resolve-url#deprecated
warning webpack > micromatch > snapdragon > source-map-resolve > urix@0.1.0: Please see https://github.com/lydell/urix#deprecated
```

</details>

</details>

## Changed files
<details>
<summary>Changed 4 files: </summary>

- gh-pages/gutenberg/package.json
- gh-pages/gutenberg/yarn.lock
- gh-pages/page/package.json
- gh-pages/page/yarn.lock

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)